### PR TITLE
Add form templates and dashboard integration for template selection #255

### DIFF
--- a/packages/formstr-app/src/components/EmptyScreen/index.tsx
+++ b/packages/formstr-app/src/components/EmptyScreen/index.tsx
@@ -5,6 +5,8 @@ import { ReactComponent as NoData } from "../../Images/no-forms.svg";
 import StyleWrapper from "./style";
 import { ROUTES } from "../../constants/routes";
 import { act } from "react-dom/test-utils";
+import { FormTemplate } from "../../templates";
+import TemplateCard from "../TemplateCard";
 
 const { Text } = Typography;
 
@@ -12,30 +14,53 @@ interface EmptyScreenProps {
   message?: string;
   action?: () => void;
   actionLabel?: string;
+  templates?: FormTemplate[];
+  onTemplateClick?: (template: FormTemplate) => void;
 }
 
-function EmptyScreen({ message, action, actionLabel }: EmptyScreenProps) {
+function EmptyScreen({ message, action, actionLabel, templates, onTemplateClick }: EmptyScreenProps) {
   let navigate = useNavigate();
   console.log("message,", message, action, actionLabel);
+  const showTemplates = templates && templates.length > 0 && onTemplateClick;
+
   return (
     <StyleWrapper>
-      <NoData className="empty-screen" />
-      <Text className="no-data">
-        {message || "Get started by creating your first form!"}
-      </Text>
-      <Button
-        className="add-form"
-        type="primary"
-        icon={action ? null : <PlusOutlined style={{ paddingTop: "2px" }} />}
-        onClick={() => {
-          if (action) action();
-          else {
-            navigate(ROUTES.CREATE_FORMS_NEW);
-          }
-        }}
-      >
-        {actionLabel || "Create Form"}
-      </Button>
+      {showTemplates ? (
+        <>
+          <Typography.Title level={4} style={{ marginBottom: '20px', textAlign: 'center' }}>
+            Start a new form
+          </Typography.Title>
+          <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', maxHeight: 'calc(100vh - 300px)', overflowY: 'auto' }}>
+            {templates.map((template) => (
+              <TemplateCard
+                key={template.id}
+                template={template}
+                onClick={onTemplateClick}
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <NoData className="empty-screen" />
+          <Text className="no-data">
+            {message || "Get started by creating your first form!"}
+          </Text>
+          <Button
+            className="add-form"
+            type="primary"
+            icon={action ? null : <PlusOutlined style={{ paddingTop: "2px" }} />}
+            onClick={() => {
+              if (action) action();
+              else {
+                navigate(ROUTES.CREATE_FORMS_NEW);
+              }
+            }}
+          >
+            {actionLabel || "Create Form"}
+          </Button>
+        </>
+      )}
     </StyleWrapper>
   );
 }

--- a/packages/formstr-app/src/components/Header/configs.tsx
+++ b/packages/formstr-app/src/components/Header/configs.tsx
@@ -36,7 +36,7 @@ export const HEADER_MENU = [
         type="primary"
         icon={<PlusOutlined style={{ paddingTop: "2px" }} />}
       >
-        <Link to={ROUTES.CREATE_FORMS_NEW}>Create Form</Link>
+        Create Form
       </Button>
     ),
   },

--- a/packages/formstr-app/src/components/Header/index.tsx
+++ b/packages/formstr-app/src/components/Header/index.tsx
@@ -18,16 +18,24 @@ import { NostrAvatar } from "./NostrAvatar";
 import { ReactComponent as GeyserIcon } from "../../Images/Geyser.svg";
 import { useState } from "react";
 import FAQModal from "../FAQModal";
+import { useApplicationContext } from '../../hooks/useApplicationContext';
 
 export const NostrHeader = () => {
   const { Header } = Layout;
   const { pubkey, requestPubkey, logout } = useProfileContext();
   const [isFAQModalVisible, setIsFAQModalVisible] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string[]>([]);
+  const { openTemplateModal } = useApplicationContext();
 
   const onMenuClick: MenuProps["onClick"] = (e) => {
     if (e.key === HEADER_MENU_KEYS.HELP) {
       setIsFAQModalVisible(true);
+      setSelectedKey([e.key]);
+      return; 
+    }
+    if (e.key === HEADER_MENU_KEYS.CREATE_FORMS) {
+      openTemplateModal();
+      return;
     }
     setSelectedKey([e.key]);
   };

--- a/packages/formstr-app/src/components/TemplateCard/index.tsx
+++ b/packages/formstr-app/src/components/TemplateCard/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Card, Typography } from 'antd';
+import styled from 'styled-components';
+import { FormTemplate } from '../../templates';
+
+const { Text, Paragraph } = Typography;
+
+const StyledCard = styled(Card)`
+  width: 180px; // Adjust width as needed
+  height: 120px; // Adjust height as needed
+  margin: 8px;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  justify-content: center; /* Center content vertically */
+  align-items: center; /* Center content horizontally */
+  text-align: center;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .ant-card-body {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%; /* Ensure body takes full height */
+  }
+`;
+
+interface TemplateCardProps {
+  template: FormTemplate;
+  onClick: (template: FormTemplate) => void;
+}
+
+const TemplateCard: React.FC<TemplateCardProps> = ({ template, onClick }) => {
+  return (
+    <StyledCard hoverable onClick={() => onClick(template)}>
+      <Text strong>{template.name}</Text>
+      {template.description && (
+        <Paragraph type="secondary" style={{ marginTop: '4px', marginBottom: 0 }} ellipsis={{ rows: 2 }}>
+          {template.description}
+        </Paragraph>
+      )}
+    </StyledCard>
+  );
+};
+
+export default TemplateCard;

--- a/packages/formstr-app/src/components/TemplateSelectorModal/index.tsx
+++ b/packages/formstr-app/src/components/TemplateSelectorModal/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Modal, Typography } from 'antd';
+import { availableTemplates, FormTemplate } from '../../templates'; 
+import TemplateCard from '../TemplateCard';
+
+interface TemplateSelectorModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onTemplateSelect: (template: FormTemplate) => void;
+}
+
+const TemplateSelectorModal: React.FC<TemplateSelectorModalProps> = ({
+  visible,
+  onClose,
+  onTemplateSelect,
+}) => {
+
+  const handleCardClick = (template: FormTemplate) => {
+    onTemplateSelect(template);
+    onClose();
+  };
+
+  return (
+    <Modal
+      title={
+        <Typography.Title level={4} style={{ textAlign: 'center', margin: 0 }}>
+          Choose a Template
+        </Typography.Title>
+      }
+      open={visible}
+      onCancel={onClose}
+      footer={null}
+      width={600}
+      centered 
+    >
+      <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', padding: '20px 0' }}>
+        {availableTemplates.map((template) => (
+          <TemplateCard
+            key={template.id}
+            template={template}
+            onClick={handleCardClick} 
+          />
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+export default TemplateSelectorModal;

--- a/packages/formstr-app/src/containers/Dashboard/index.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/index.tsx
@@ -15,6 +15,13 @@ import { DownOutlined } from "@ant-design/icons";
 import { MyForms } from "./FormCards/MyForms";
 import { Drafts } from "./FormCards/Drafts";
 import { LocalForms } from "./FormCards/LocalForms";
+import { useNavigate } from "react-router-dom"; 
+import { availableTemplates, FormTemplate } from "../../templates";
+import TemplateCard from "../../components/TemplateCard";
+import { ROUTES } from "../../constants/routes";
+import { makeTag } from "../../utils/utility";
+import { FormInitData } from "../CreateFormNew/providers/FormBuilder/typeDefs";
+import { Tag } from "../../nostr/types";
 const MENU_OPTIONS = {
   local: "On this device",
   shared: "Shared with me",
@@ -77,6 +84,28 @@ export const Dashboard = () => {
     };
   }, [pubkey]);
 
+  const navigate = useNavigate();
+
+  const handleTemplateClick = (template: FormTemplate) => {
+    const newFormInstanceId = makeTag(6);
+
+    const transformedQuestionsList = template.initialState.questionsList.map(field => {
+      const transformedField = [...field];
+      transformedField[0] = "field";
+      return transformedField;
+    }) as Tag[];
+    const spec: Tag[] = [
+      ["d", newFormInstanceId], 
+      ["name", template.initialState.formName],
+      ["settings", JSON.stringify(template.initialState.formSettings)],
+      ...transformedQuestionsList,
+    ];
+    const navigationState: FormInitData = {
+      spec: spec,
+      id: newFormInstanceId, 
+    };
+    navigate(ROUTES.CREATE_FORMS_NEW, { state: navigationState });
+  };  
   const renderForms = () => {
     if (filter === "local") {
       if (localForms.length == 0) return <EmptyScreen />;
@@ -133,6 +162,20 @@ export const Dashboard = () => {
   return (
     <DashboardStyleWrapper>
       <div className="dashboard-container">
+      <div style={{ padding: '20px 0', borderBottom: '1px solid #eee', marginBottom: '20px' }}>
+            <Typography.Title level={4} style={{ textAlign: 'center', marginBottom: '16px' }}>
+              Start a new form
+            </Typography.Title>
+            <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
+              {availableTemplates.map((template) => (
+                <TemplateCard
+                  key={template.id}
+                  template={template}
+                  onClick={handleTemplateClick}
+                />
+              ))}
+            </div>
+          </div>
         <div style={{ margin: 10 }}>
           <Dropdown overlay={menu} trigger={["click"]} placement="bottomLeft">
             <div

--- a/packages/formstr-app/src/containers/Dashboard/index.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/index.tsx
@@ -18,10 +18,10 @@ import { LocalForms } from "./FormCards/LocalForms";
 import { useNavigate } from "react-router-dom"; 
 import { availableTemplates, FormTemplate } from "../../templates";
 import { ROUTES } from "../../constants/routes";
-import { makeTag } from "../../utils/utility";
 import { FormInitData } from "../CreateFormNew/providers/FormBuilder/typeDefs";
-import { Tag } from "../../nostr/types";
 import TemplateSelectorModal from "../../components/TemplateSelectorModal";
+import { createFormSpecFromTemplate } from "../../utils/formUtils";
+
 const MENU_OPTIONS = {
   local: "On this device",
   shared: "Shared with me",
@@ -87,25 +87,11 @@ export const Dashboard = () => {
   const navigate = useNavigate();
 
   const handleTemplateClick = (template: FormTemplate) => {
-    const newFormInstanceId = makeTag(6);
-
-    const transformedQuestionsList = template.initialState.questionsList.map(field => {
-      const transformedField = [...field];
-      transformedField[0] = "field";
-      return transformedField;
-    }) as Tag[];
-    const spec: Tag[] = [
-      ["d", newFormInstanceId], 
-      ["name", template.initialState.formName],
-      ["settings", JSON.stringify(template.initialState.formSettings)],
-      ...transformedQuestionsList,
-    ];
-    const navigationState: FormInitData = {
-      spec: spec,
-      id: newFormInstanceId, 
-    };
+    const { spec, id } = createFormSpecFromTemplate(template);
+    const navigationState: FormInitData = { spec, id };
     navigate(ROUTES.CREATE_FORMS_NEW, { state: navigationState });
-  };  
+  };
+
   const renderForms = () => {
     if (filter === "local") {
       if (localForms.length == 0){ 

--- a/packages/formstr-app/src/provider/ApplicationProvider.tsx
+++ b/packages/formstr-app/src/provider/ApplicationProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FC, ReactNode, useRef } from "react";
+import React, { createContext, FC, ReactNode, useRef, useState } from "react";
 import { SimplePool } from "nostr-tools";
 
 interface ApplicationProviderProps {
@@ -7,6 +7,9 @@ interface ApplicationProviderProps {
 
 export interface ApplicationContextType {
   poolRef: React.MutableRefObject<SimplePool>;
+  isTemplateModalOpen: boolean;
+  openTemplateModal: () => void;
+  closeTemplateModal: () => void;
 }
 
 export const ApplicationContext = createContext<
@@ -17,9 +20,18 @@ export const ApplicationProvider: FC<ApplicationProviderProps> = ({
   children,
 }) => {
   const poolRef = useRef(new SimplePool());
+  const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false);
+  const openTemplateModal = () => setIsTemplateModalOpen(true); 
+  const closeTemplateModal = () => setIsTemplateModalOpen(false);
+  const contextValue: ApplicationContextType = {
+    poolRef,
+    isTemplateModalOpen,
+    openTemplateModal,
+    closeTemplateModal,
+  };
 
   return (
-    <ApplicationContext.Provider value={{ poolRef }}>
+    <ApplicationContext.Provider value={ contextValue }>
       {children}
     </ApplicationContext.Provider>
   );

--- a/packages/formstr-app/src/templates/blank.ts
+++ b/packages/formstr-app/src/templates/blank.ts
@@ -21,7 +21,7 @@ export const blankTemplate: FormTemplate = {
     },
     questionsList: [
        [
-        '', // placeholder (unused in Field tuple)
+        'field', 
         generateFieldId(), // Use generated ID
         'text', // dataType (primitive type)
         'Untitled Question', // label

--- a/packages/formstr-app/src/templates/blank.ts
+++ b/packages/formstr-app/src/templates/blank.ts
@@ -1,0 +1,35 @@
+import { FormTemplate } from './types';
+import { Field } from '../nostr/types'; 
+
+let fieldCounter = 0;
+const generateFieldId = (): string => `template_field_${Date.now()}_${fieldCounter++}`;
+
+export const blankTemplate: FormTemplate = {
+  id: 'blank',
+  name: 'Blank Form',
+  description: 'Start with a clean slate.',
+  initialState: {
+    formName: 'Untitled Form',
+    formSettings: {
+      description: 'escription here',
+      thankYouPage: true,
+      notifyNpubs: [],
+      publicForm: true,
+      disallowAnonymous: false,
+      encryptForm: true,
+      viewKeyInUrl: true,
+    },
+    questionsList: [
+       [
+        '', // placeholder (unused in Field tuple)
+        generateFieldId(), // Use generated ID
+        'text', // dataType (primitive type)
+        'Untitled Question', // label
+        '[]', // options (empty stringified array for non-option types)
+        '{"renderElement": "shortText"}', // config (includes renderElement)
+      ] as Field, // Assert type for tuple safety
+    ],
+  },
+};
+
+fieldCounter = 0;

--- a/packages/formstr-app/src/templates/contactInfo.ts
+++ b/packages/formstr-app/src/templates/contactInfo.ts
@@ -24,7 +24,7 @@ export const contactInfoTemplate: FormTemplate = {
     questionsList: [
       // Field 1: Name (Required, Short Text)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Name', // label
@@ -34,7 +34,7 @@ export const contactInfoTemplate: FormTemplate = {
 
       // Field 2: Email (Required, Short Text, with validation)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Email', // label
@@ -53,7 +53,7 @@ export const contactInfoTemplate: FormTemplate = {
 
       // Field 3: Address (Required, Paragraph)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Address', // label
@@ -63,7 +63,7 @@ export const contactInfoTemplate: FormTemplate = {
 
       // Field 4: Phone number (Not Required, Short Text)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Phone number', // label
@@ -73,7 +73,7 @@ export const contactInfoTemplate: FormTemplate = {
 
        // Field 5: Comments (Not Required, Paragraph)
        [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Comments', // label

--- a/packages/formstr-app/src/templates/contactInfo.ts
+++ b/packages/formstr-app/src/templates/contactInfo.ts
@@ -1,0 +1,87 @@
+import { FormTemplate } from './types';
+import { Field } from '../nostr/types';
+
+let fieldCounter = 0;
+const generateFieldId = (): string => `template_field_${Date.now()}_${fieldCounter++}`;
+
+const emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+export const contactInfoTemplate: FormTemplate = {
+  id: 'contactInfo',
+  name: 'Contact Info',
+  description: 'Gather contact details.',
+  initialState: {
+    formName: 'Contact Information',
+    formSettings: {
+      description: 'Contact details.',
+      thankYouPage: true,
+      notifyNpubs: [],
+      publicForm: true,
+      disallowAnonymous: false,
+      encryptForm: true,
+      viewKeyInUrl: true,
+    },
+    questionsList: [
+      // Field 1: Name (Required, Short Text)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Name', // label
+        '[]', // options
+        '{"renderElement": "shortText", "required": true}', // config
+      ] as Field,
+
+      // Field 2: Email (Required, Short Text, with validation)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Email', // label
+        '[]', // options
+        JSON.stringify({ // Stringify the config object
+          renderElement: "shortText",
+          required: true,
+          validationRules: {
+            regex: {
+              pattern: emailRegex,
+              errorMessage: "Please enter a valid email address."
+            }
+          }
+        }), // config
+      ] as Field,
+
+      // Field 3: Address (Required, Paragraph)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Address', // label
+        '[]', // options
+        '{"renderElement": "paragraph", "required": true}', // config (Assuming 'paragraph' exists)
+      ] as Field,
+
+      // Field 4: Phone number (Not Required, Short Text)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Phone number', // label
+        '[]', // options
+        '{"renderElement": "shortText", "required": false}', // config
+      ] as Field,
+
+       // Field 5: Comments (Not Required, Paragraph)
+       [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Comments', // label
+        '[]', // options
+        '{"renderElement": "paragraph", "required": false}', // config (Assuming 'paragraph' exists)
+      ] as Field,
+    ],
+  },
+};
+
+fieldCounter = 0;

--- a/packages/formstr-app/src/templates/eventRegistration.ts
+++ b/packages/formstr-app/src/templates/eventRegistration.ts
@@ -1,0 +1,123 @@
+import { FormTemplate } from './types';
+import { Field, Option } from '../nostr/types';
+
+let fieldCounter = 0;
+let optionCounter = 0;
+const generateFieldId = (): string => `template_field_${Date.now()}_${fieldCounter++}`;
+const generateOptionId = (): string => `template_option_${Date.now()}_${optionCounter++}`;
+
+const createOptionsString = (options: Array<[string, string]>): string => {
+    const optionsWithIds: Option[] = options.map(([label]) => [generateOptionId(), label]);
+    return JSON.stringify(optionsWithIds);
+};
+
+const emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+const eventDescription = `Event Timing: January 4th-6th, 2016
+Event Address: 123 Your Street Your City, ST 12345
+Contact us at (123) 456-7890 or no_reply@example.com
+`;
+
+export const eventRegistrationTemplate: FormTemplate = {
+  id: 'eventRegistration',
+  name: 'Event Registration',
+  description: 'Register attendees for an event.', 
+  initialState: {
+    formName: 'Event Registration', 
+    formSettings: {
+      description: eventDescription, 
+      thankYouPage: true,
+      notifyNpubs: [],
+      publicForm: true,
+      disallowAnonymous: false,
+      encryptForm: true,
+      viewKeyInUrl: true,
+    },
+    questionsList: [
+      // Field 1: Name (Required, Short Text)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Name', // label
+        '[]', // options
+        '{"renderElement": "shortText", "required": true}', // config
+      ] as Field,
+
+      // Field 2: Email (Required, Short Text, Email Validation)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Email', // label
+        '[]', // options
+        JSON.stringify({
+            renderElement: "shortText",
+            required: true,
+            validationRules: {
+              regex: {
+                pattern: emailRegex,
+                errorMessage: "Please enter a valid email address."
+              }
+            }
+          }), // config
+      ] as Field,
+
+      // Field 3: Organization (Required, Short Text)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Organization', // label
+        '[]', // options
+        '{"renderElement": "shortText", "required": true}', // config
+      ] as Field,
+
+      // Field 4: Days Attending (Required, Multiple Choice / Checkboxes)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'What days will you attend?', // label
+        createOptionsString([
+          ["Day 1", ""],
+          ["Day 2", ""],
+          ["Day 3", ""],
+        ]), // options
+        '{"renderElement": "checkboxes", "required": true}', // config
+      ] as Field,
+
+      // Field 5: Dietary Restrictions (Required, Single Choice / Radio Buttons)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'Dietary restrictions', // label
+        createOptionsString([
+          ["None", ""],
+          ["Vegetarian", ""],
+          ["Vegan", ""],
+          ["Kosher", ""],
+          ["Gluten-free", ""],
+          ["Other:", ""],
+        ]), // options
+        '{"renderElement": "radioButton", "required": true}', // config
+      ] as Field,
+
+      // Field 6: Payment Understanding (Required, Single Choice / Radio Button)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'I understand that I will have to pay $$ upon arrival', // label
+        createOptionsString([
+          ["Yes", ""],
+        ]), // options (Only "Yes")
+        '{"renderElement": "radioButton", "required": true}', // config
+      ] as Field,
+    ],
+  },
+};
+
+fieldCounter = 0;
+optionCounter = 0;

--- a/packages/formstr-app/src/templates/eventRegistration.ts
+++ b/packages/formstr-app/src/templates/eventRegistration.ts
@@ -36,7 +36,7 @@ export const eventRegistrationTemplate: FormTemplate = {
     questionsList: [
       // Field 1: Name (Required, Short Text)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Name', // label
@@ -46,7 +46,7 @@ export const eventRegistrationTemplate: FormTemplate = {
 
       // Field 2: Email (Required, Short Text, Email Validation)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Email', // label
@@ -65,7 +65,7 @@ export const eventRegistrationTemplate: FormTemplate = {
 
       // Field 3: Organization (Required, Short Text)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Organization', // label
@@ -75,7 +75,7 @@ export const eventRegistrationTemplate: FormTemplate = {
 
       // Field 4: Days Attending (Required, Multiple Choice / Checkboxes)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'What days will you attend?', // label
@@ -89,7 +89,7 @@ export const eventRegistrationTemplate: FormTemplate = {
 
       // Field 5: Dietary Restrictions (Required, Single Choice / Radio Buttons)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'Dietary restrictions', // label
@@ -106,7 +106,7 @@ export const eventRegistrationTemplate: FormTemplate = {
 
       // Field 6: Payment Understanding (Required, Single Choice / Radio Button)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'I understand that I will have to pay $$ upon arrival', // label

--- a/packages/formstr-app/src/templates/index.ts
+++ b/packages/formstr-app/src/templates/index.ts
@@ -1,0 +1,24 @@
+import { blankTemplate } from './blank';
+import { rsvpTemplate } from './rsvp';
+import { contactInfoTemplate } from './contactInfo';
+import { eventRegistrationTemplate } from './eventRegistration';
+import { partyInviteTemplate } from './partyInvite';
+import { FormTemplate } from './types';
+
+export const availableTemplates: FormTemplate[] = [
+  blankTemplate,
+  rsvpTemplate,
+  contactInfoTemplate,
+  partyInviteTemplate,
+  eventRegistrationTemplate,
+];
+
+// export {blankTemplate, 
+//         rsvpTemplate,
+//         contactInfoTemplate,
+//         partyInviteTemplate,
+//         eventRegistrationTemplate
+//       };
+
+
+export * from './types';

--- a/packages/formstr-app/src/templates/partyInvite.ts
+++ b/packages/formstr-app/src/templates/partyInvite.ts
@@ -1,0 +1,117 @@
+import { FormTemplate } from './types';
+import { Field, Option } from '../nostr/types';
+
+let fieldCounter = 0;
+let optionCounter = 0;
+const generateFieldId = (): string => `template_field_${Date.now()}_${fieldCounter++}`;
+const generateOptionId = (): string => `template_option_${Date.now()}_${optionCounter++}`;
+
+const createOptionsString = (options: Array<[string, string]>): string => {
+    const optionsWithIds: Option[] = options.map(([label]) => [generateOptionId(), label]);
+    return JSON.stringify(optionsWithIds);
+};
+
+const emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+const partyDescription = `Party description here`;
+
+export const partyInviteTemplate: FormTemplate = {
+  id: 'partyInvite',
+  name: 'Party Invite',
+  description: 'Invite guests to a party.',
+  initialState: {
+    formName: 'Party Invite', 
+    formSettings: {
+      description: partyDescription, 
+      thankYouPage: true,
+      notifyNpubs: [],
+      publicForm: true,
+      disallowAnonymous: false,
+      encryptForm: true,
+      viewKeyInUrl: true,
+    },
+    questionsList: [
+      // Field 1: Name (Required, Short Text)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'What is your name?', // label
+        '[]', // options
+        '{"renderElement": "shortText", "required": true}', // config
+      ] as Field,
+
+      // Field 2: Attendance (Required, Single Choice / Radio Button)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'Can you attend?', // label
+        createOptionsString([
+          ["Yes, I'll be there", ""],
+          ["Sorry, can't make it", ""],
+        ]), // options
+        '{"renderElement": "radioButton", "required": true}', // config
+      ] as Field,
+
+       // Field 3: How many attending (Not Required, Number)
+       [
+        '', // placeholder
+        generateFieldId(),
+        'number', // dataType
+        'How many of you are attending?', // label
+        '[]', // options
+        '{"renderElement": "number", "required": false, "min": 1}', // config (min 1 if they enter a number)
+      ] as Field,
+
+      // Field 4: What bringing (Not Required, Multiple Choice / Checkboxes)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'What will you be bringing? (Let us know what kind of dish(es) you\'ll be bringing)', // label (Combined for clarity)
+        createOptionsString([
+          ["Mains", ""],
+          ["Salad", ""],
+          ["Dessert", ""],
+          ["Drinks", ""],
+          ["Sides/Appetizers", ""],
+          ["Other:", ""], // Included "Other" as a standard option
+        ]), // options
+        '{"renderElement": "checkboxes", "required": false}', // config
+      ] as Field,
+
+       // Field 5: Allergies (Not Required, Paragraph)
+       [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Do you have any allergies or dietary restrictions?', // label
+        '[]', // options
+        '{"renderElement": "paragraph", "required": false}', // config
+      ] as Field,
+
+      // Field 6: Email (Not Required, Short Text, Email Validation)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'What is your email address?', // label
+        '[]', // options
+        JSON.stringify({ // Stringify the config object
+            renderElement: "shortText",
+            required: false, // Set to false as per field list
+            validationRules: {
+              regex: {
+                pattern: emailRegex,
+                errorMessage: "Please enter a valid email address."
+              }
+            }
+          }), // config
+      ] as Field,
+    ],
+  },
+};
+
+fieldCounter = 0;
+optionCounter = 0;

--- a/packages/formstr-app/src/templates/partyInvite.ts
+++ b/packages/formstr-app/src/templates/partyInvite.ts
@@ -33,7 +33,7 @@ export const partyInviteTemplate: FormTemplate = {
     questionsList: [
       // Field 1: Name (Required, Short Text)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'What is your name?', // label
@@ -43,7 +43,7 @@ export const partyInviteTemplate: FormTemplate = {
 
       // Field 2: Attendance (Required, Single Choice / Radio Button)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'Can you attend?', // label
@@ -56,7 +56,7 @@ export const partyInviteTemplate: FormTemplate = {
 
        // Field 3: How many attending (Not Required, Number)
        [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'number', // dataType
         'How many of you are attending?', // label
@@ -66,7 +66,7 @@ export const partyInviteTemplate: FormTemplate = {
 
       // Field 4: What bringing (Not Required, Multiple Choice / Checkboxes)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'What will you be bringing? (Let us know what kind of dish(es) you\'ll be bringing)', // label (Combined for clarity)
@@ -83,7 +83,7 @@ export const partyInviteTemplate: FormTemplate = {
 
        // Field 5: Allergies (Not Required, Paragraph)
        [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Do you have any allergies or dietary restrictions?', // label
@@ -93,7 +93,7 @@ export const partyInviteTemplate: FormTemplate = {
 
       // Field 6: Email (Not Required, Short Text, Email Validation)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'What is your email address?', // label

--- a/packages/formstr-app/src/templates/rsvp.ts
+++ b/packages/formstr-app/src/templates/rsvp.ts
@@ -31,7 +31,7 @@ export const rsvpTemplate: FormTemplate = {
     },
     questionsList: [
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'Can you attend?', // label
@@ -44,7 +44,7 @@ export const rsvpTemplate: FormTemplate = {
 
       // Field 2: Names of Attendees (Text / Paragraph)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'What are the names of people attending?', // label
@@ -54,7 +54,7 @@ export const rsvpTemplate: FormTemplate = {
 
       // Field 3: How Heard (Multiple Choice / Checkboxes)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'option', // dataType
         'How did you hear about this event?', // label
@@ -69,7 +69,7 @@ export const rsvpTemplate: FormTemplate = {
 
       // Field 4: Comments (Text / Paragraph)
       [
-        '', // placeholder
+        'field', 
         generateFieldId(),
         'text', // dataType
         'Comments and/or questions', // label

--- a/packages/formstr-app/src/templates/rsvp.ts
+++ b/packages/formstr-app/src/templates/rsvp.ts
@@ -1,0 +1,84 @@
+import { FormTemplate } from './types';
+import { Field, Option } from '../nostr/types';
+
+let fieldCounter = 0;
+let optionCounter = 0;
+const generateFieldId = (): string => `template_field_${Date.now()}_${fieldCounter++}`;
+const generateOptionId = (): string => `template_option_${Date.now()}_${optionCounter++}`;
+
+const createOptionsString = (options: Array<[string, string]>): string => {
+    const optionsWithIds: Option[] = options.map(([label]) => [generateOptionId(), label]);
+    return JSON.stringify(optionsWithIds);
+};
+
+const rsvpDescription = `Event Address: 123 Your Street Your City, ST 12345
+Contact us at (123) 456-7890 or no_reply@example.com`;
+
+export const rsvpTemplate: FormTemplate = {
+  id: 'rsvp',
+  name: 'RSVP', 
+  description: 'Collect attendance for an event.',
+  initialState: {
+    formName: 'Event RSVP',
+    formSettings: {
+      description: rsvpDescription,
+      thankYouPage: true,
+      notifyNpubs: [],
+      publicForm: true,
+      disallowAnonymous: false,
+      encryptForm: true,
+      viewKeyInUrl: true,
+    },
+    questionsList: [
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'Can you attend?', // label
+        createOptionsString([
+          ["Yes, I'll be there", ""],
+          ["Sorry, can't make it", ""],
+        ]), // options
+        '{"renderElement": "radioButton", "required": true}', // config (Radio button, required)
+      ] as Field,
+
+      // Field 2: Names of Attendees (Text / Paragraph)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'What are the names of people attending?', // label
+        '[]', // options (none)
+        '{"renderElement": "paragraph", "required": false}', // config (Using paragraph for potentially long list, not required)
+      ] as Field,
+
+      // Field 3: How Heard (Multiple Choice / Checkboxes)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'option', // dataType
+        'How did you hear about this event?', // label
+        createOptionsString([
+          ["Website", ""],
+          ["Friend", ""],
+          ["Newsletter", ""],
+          ["Advertisement", ""],
+        ]), // options
+        '{"renderElement": "checkboxes", "required": false}', // config (Checkboxes, not required)
+      ] as Field,
+
+      // Field 4: Comments (Text / Paragraph)
+      [
+        '', // placeholder
+        generateFieldId(),
+        'text', // dataType
+        'Comments and/or questions', // label
+        '[]', // options (none)
+        '{"renderElement": "paragraph", "required": false}', // config (Using paragraph, not required)
+      ] as Field,
+    ],
+  },
+};
+
+fieldCounter = 0;
+optionCounter = 0;

--- a/packages/formstr-app/src/templates/types.ts
+++ b/packages/formstr-app/src/templates/types.ts
@@ -1,0 +1,13 @@
+import { Field } from '../nostr/types';
+import { IFormSettings } from '../containers/CreateFormNew/components/FormSettings/types';
+
+export interface FormTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  initialState: {
+    formName: string;
+    formSettings: IFormSettings;
+    questionsList: Field[];
+  };
+}

--- a/packages/formstr-app/src/utils/formUtils.ts
+++ b/packages/formstr-app/src/utils/formUtils.ts
@@ -1,9 +1,22 @@
+import { FormTemplate } from "../templates";
+import { makeTag } from "./utility";
 import { getDefaultRelays } from "@formstr/sdk";
 import { Tag } from "@formstr/sdk/dist/formstr/nip101";
 import { nip44, Event, UnsignedEvent, SimplePool, nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils";
 import { sha256 } from "@noble/hashes/sha256";
 import { naddrUrl } from "./utility";
+
+export const createFormSpecFromTemplate = (template: FormTemplate): { spec: Tag[], id: string } => {
+  const newFormInstanceId = makeTag(6);
+  const spec: Tag[] = [
+    ["d", newFormInstanceId],
+    ["name", template.initialState.formName],
+    ["settings", JSON.stringify(template.initialState.formSettings)],
+    ...(template.initialState.questionsList as Tag[]),
+  ];
+  return { spec, id: newFormInstanceId };
+};
 
 export const fetchKeys = async (
   formAuthor: string,


### PR DESCRIPTION
Feature: Add Pre-made Form Templates

This pull request adds functionality for users to start creating forms from pre-defined templates.

A new section titled "Start a new form" has been added to the top of the Dashboard.

This section displays cards for several common templates (e.g., Blank, RSVP, Contact Info, Party Invite, Event Registration).

Clicking a template card navigates the user to the form builder, pre-populating it with the selected template's structure and content.

Includes new template definition files (src/templates/) and a TemplateCard UI component.

This feature provides users with convenient starting points for common form types, enhancing usability.