### PR TITLE
docs: Add README, architecture, and usage guide for formstr #60

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -1,0 +1,101 @@
+#  Architecture – Formstr on Nostr
+
+## Overview
+
+Formstr is a decentralized form creation and submission platform built on the [Nostr Protocol](https://github.com/nostr-protocol/nostr). It leverages Nostr events and public key infrastructure to handle creation, sharing, and response collection for forms.
+
+---
+
+##  Core Concepts
+
+- **Forms** are stored as Nostr events.
+- **Responses** to forms are also Nostr events, linked by a unique form ID.
+- Each user is identified by their **Nostr public key**.
+- Formstr uses **NIP-07** for authentication via browser extensions.
+
+---
+
+##  Architecture Components
+
+### 1. Web App (`@formstr/web-app`)
+
+- React-based frontend
+- Allows users to:
+  - Create forms
+  - View and fill forms
+  - View response analytics
+- Communicates with the SDK to read/write to Nostr
+
+### 2. SDK (`@formstr/sdk`)
+
+- Handles:
+  - Form creation (publishing form metadata as Nostr events)
+  - Response submission
+  - Fetching events by form ID or author pubkey
+- Manages event signatures and validation
+
+### 3. Nostr Protocol
+
+- Used for all data transport and storage
+- Events are signed using the user's private key (NIP-07 compliant)
+- Forms and responses are both stored as `kind=30023` or custom kinds
+- Uses relays to propagate events across the network
+
+---
+
+##  Workflow
+
+###  Form Creation
+
+1. User fills out form fields using the UI
+2. SDK constructs a Nostr event with:
+   - `kind`: custom (e.g. 30023)
+   - `content`: JSON representing the form schema
+   - `tags`: metadata (e.g., `["d", "form_id"]`)
+3. Event is signed and published using NIP-07
+4. Form is now live on Nostr
+
+###  Response Submission
+
+1. User fills out the live form
+2. SDK constructs a new Nostr event:
+   - References the original form ID in `tags`
+   - Includes filled values in `content`
+3. Signed with the respondent's pubkey and published
+
+###  Fetching Forms/Responses
+
+- To fetch a form:
+  - Query Nostr relays using `kind` and `pubkey` or `form_id`
+- To fetch responses:
+  - Query events that tag the form ID
+  - Filter by `kind`, `pubkey`, or timestamp
+
+---
+
+##  Formstr Event Specification
+
+### Form Event
+
+
+```json
+{
+  "kind": 30023,
+  "content": "{\"title\":\"Survey 1\",\"fields\":[{\"label\":\"Name\",\"type\":\"text\"}]}",
+  "tags": [["d", "form:123"], ["type", "form"]],
+  "pubkey": "<creator_pubkey>"
+}
+```
+
+### Response Event
+
+```json
+{
+  "kind": 30024,
+  "content": "{\"Name\":\"Rahul\"}",
+  "tags": [["e", "<form_event_id>"], ["type", "response"]],
+  "pubkey": "<responder_pubkey>"
+}
+```
+### Contact
+For clarifications, reach out to [https://github.com/abh3po](@abh3po)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-This repository holds the forms implementation on the [nostr-protocol](https://github.com/nostr-protocol/nostr)
+# Formstr – Forms on Nostr Protocol
+
+**Formstr** is a decentralized form management application built on top of the [Nostr Protocol](https://github.com/nostr-protocol/nostr). It allows users to create, publish, and fill out forms using decentralized identity and event-based communication.
+
+## ✨ Features
+
+- Create forms via a UI or SDK
+- Store form metadata and responses on Nostr
+- Validate and manage form responses
+- Export responses as CSV
+- Fully decentralized – powered by Nostr and NIP-07
 
 ## Setup
 

--- a/packages/formstr-sdk/docs/v1/UsingFormstr.md
+++ b/packages/formstr-sdk/docs/v1/UsingFormstr.md
@@ -1,0 +1,91 @@
+# Using Formstr via UI and SDK
+
+This document covers how to create, fetch, and fill forms using the Formstr platform via both the UI and SDK.
+
+---
+
+## 1. Creating a Form
+
+### 🖥️ Using the UI
+
+1. Go to [https://formstr.app](https://formstr.app).
+2. Connect your Nostr-compatible signer extension (e.g., NIP-07 extension).
+3. Click on **"Create New Form"**.
+4. Add your form fields using the builder interface.
+5. Save and publish — your form is now available on the Nostr network.
+
+### 💻 Using the SDK
+
+```ts
+import { createForm } from "@formstr/sdk";
+
+const form = {
+  title: "Feedback Form",
+  description: "Collect feedback from users",
+  fields: [
+    {
+      type: "text",
+      label: "Name",
+      required: true
+    },
+    {
+      type: "email",
+      label: "Email",
+      required: false
+    },
+    {
+      type: "textarea",
+      label: "Feedback",
+      required: true
+    }
+  ]
+};
+
+const result = await createForm(form, signer);
+console.log("Form created:", result);
+```
+
+## 2. Fetching a Form
+
+### 🖥️ Using the UI
+
+- Navigate to the homepage or search bar.
+- Enter the form ID or browse your existing forms.
+- Click on the form title to open it and view the questions.
+
+### 💻 Using the SDK
+
+```ts
+import { fetchForm } from "@formstr/sdk";
+
+const formId = "<form_id_here>";
+const form = await fetchForm(formId);
+console.log("Fetched form:", form);
+```
+## 3. Form Filling and Validation Errors
+
+### 🖥️ Using the UI
+
+- Required fields are marked with a red asterisk (*).
+- Real-time validation is performed (e.g., email format check).
+- On submit, any missing required fields are highlighted.
+- If all validations pass, the form is submitted to the Nostr network.
+
+### 💻 Using the SDK
+
+```ts
+import { submitForm } from "@formstr/sdk";
+
+const formId = "<form_id_here>";
+const formData = {
+  Name: "Rahul",
+  Email: "rahul@example.com",
+  Feedback: "Great platform!"
+};
+
+try {
+  await submitForm(formId, formData, signer);
+  console.log("Form submitted successfully");
+} catch (error) {
+  console.error("Validation or submission failed:", error.message);
+}


### PR DESCRIPTION
This PR adds documentation to help contributors and users get started with Formstr. It includes:

- A detailed `README.md` with setup instructions
- `Architecture.md` outlining interaction with the Nostr protocol
- `UsingFormstr.md` (in SDK docs) explaining how to:
  - Create a form via UI/SDK
  - Fetch a form via UI/SDK
  - Submit and validate a form via UI/SDK

resolves #60 
@abh3po 