### PR TITLE
Draft pr for Ollama integration

### DIFF
--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/AIProcessor.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/AIProcessor.ts
@@ -1,11 +1,11 @@
 import { GenerationResponse } from "../../services/ollamaService";
 import { AIProcessingProps } from "./types";
+import {generateQuestion}from "../../utils";
+import { INPUTS_TYPES } from "../../configs/constants";
 
 export const mapFieldTypeToFormType = (type: string = ''): string => {
-  // Convert to lowercase for case-insensitive matching
   const typeStr = type.toLowerCase();
 
-  // Exact matching for the specific types we instructed the LLM to use
   switch (typeStr) {
     case 'multiple_choice':
       return 'MULTIPLE_CHOICE';
@@ -66,29 +66,20 @@ export const processAIResponse = async (
   const { updateQuestionsList, updateFormName, formSettings, updateFormSetting } = props;
   
   if (response.success && response.fields) {
-    // Extract form name from the response or use a default based on the prompt
+
     const formName = response.fields[0]?.formName || 
                     response.formName || 
                     prompt.split(' ').slice(0, 3).join(' ') ||
                     'AI Generated Form';
 
-    // Extract form description if available
     const formDescription = response.description || 
                           response.fields[0]?.description || 
                           `Form generated from prompt: ${prompt}`;
-
-    // Convert the AI-generated fields to the format expected by Formstr
-    const { generateQuestion } = await import('../../utils');
-    const { INPUTS_TYPES } = await import('../../configs/constants');
     
     const convertedFields = response.fields?.map((field: any, index: number) => {
-      // Ensure field has an ID
-      const fieldId = field.id || `field_${index}`;
-      
-      // Map the AI field type to Formstr types
-      const formType = mapFieldTypeToFormType(field.type);
 
-      // Convert options to choices format if available
+      const fieldId = field.id || `field_${index}`;
+      const formType = mapFieldTypeToFormType(field.type);
       let choices: [string, string][] = [];
       
       // Handle options for choice-based fields
@@ -120,17 +111,15 @@ export const processAIResponse = async (
         primitive = 'number';
       }
 
-      // Map to correct renderElement
       const renderElement = mapTypeToRenderElement(formType);
 
-      // Additional settings for the field
       const settings = {
         required: !!field.required,
         renderElement,
         description: field.description || '',
         placeholder: field.placeholder || '',
         fieldId: fieldId,
-        defaultValue: undefined, // Add default property to the object
+        defaultValue: undefined,
       };
 
       // Add default answer for required fields if specified

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/AIProcessor.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/AIProcessor.ts
@@ -1,0 +1,159 @@
+import { GenerationResponse } from "../../services/ollamaService";
+import { AIProcessingProps } from "./types";
+
+export const mapFieldTypeToFormType = (type: string = ''): string => {
+  // Convert to lowercase for case-insensitive matching
+  const typeStr = type.toLowerCase();
+
+  // Exact matching for the specific types we instructed the LLM to use
+  switch (typeStr) {
+    case 'multiple_choice':
+      return 'MULTIPLE_CHOICE';
+    case 'single_choice':
+      return 'SINGLE_CHOICE';
+    case 'dropdown':
+      return 'SELECT';
+    case 'paragraph':
+      return 'PARAGRAPH';
+    case 'number':
+      return 'NUMBER';
+    case 'date':
+      return 'DATE';
+    case 'time':
+      return 'TIME';
+    case 'short_text':
+      return 'SHORT_ANSWER';
+    default:
+      // Fallback to more flexible matching for backward compatibility
+      if (typeStr.includes('multiple') || typeStr.includes('checkbox')) {
+        return 'MULTIPLE_CHOICE';
+      } else if (typeStr.includes('single') || typeStr.includes('radio')) {
+        return 'SINGLE_CHOICE';
+      } else if (typeStr.includes('dropdown') || typeStr.includes('select')) {
+        return 'SELECT';
+      } else if (typeStr.includes('paragraph') || typeStr.includes('long')) {
+        return 'PARAGRAPH';
+      } else if (typeStr.includes('number')) {
+        return 'NUMBER';
+      } else if (typeStr.includes('date')) {
+        return 'DATE';
+      } else if (typeStr.includes('time')) {
+        return 'TIME';
+      } else {
+        return 'SHORT_ANSWER';
+      }
+  }
+};
+
+export const mapTypeToRenderElement = (type: string): string => {
+  switch (type) {
+    case 'MULTIPLE_CHOICE': return 'checkboxes';
+    case 'SINGLE_CHOICE': return 'radioButton';
+    case 'SELECT': return 'dropdown';
+    case 'PARAGRAPH': return 'paragraph';
+    case 'NUMBER': return 'number';
+    case 'DATE': return 'date';
+    case 'TIME': return 'time';
+    default: return 'shortText';
+  }
+};
+
+export const processAIResponse = async (
+  response: GenerationResponse, 
+  prompt: string,
+  props: AIProcessingProps
+) => {
+  const { updateQuestionsList, updateFormName, formSettings, updateFormSetting } = props;
+  
+  if (response.success && response.fields) {
+    // Extract form name from the response or use a default based on the prompt
+    const formName = response.fields[0]?.formName || 
+                    response.formName || 
+                    prompt.split(' ').slice(0, 3).join(' ') ||
+                    'AI Generated Form';
+
+    // Extract form description if available
+    const formDescription = response.description || 
+                          response.fields[0]?.description || 
+                          `Form generated from prompt: ${prompt}`;
+
+    // Convert the AI-generated fields to the format expected by Formstr
+    const { generateQuestion } = await import('../../utils');
+    const { INPUTS_TYPES } = await import('../../configs/constants');
+    
+    const convertedFields = response.fields?.map((field: any, index: number) => {
+      // Ensure field has an ID
+      const fieldId = field.id || `field_${index}`;
+      
+      // Map the AI field type to Formstr types
+      const formType = mapFieldTypeToFormType(field.type);
+
+      // Convert options to choices format if available
+      let choices: [string, string][] = [];
+      
+      // Handle options for choice-based fields
+      if (field.options && Array.isArray(field.options)) {
+        // Make sure options are converted to strings to avoid 'object Object'
+        choices = field.options.map((option: any, optIndex: number) => {
+          const optionValue = typeof option === 'object' ? JSON.stringify(option) : String(option);
+          return [String(optIndex), optionValue];
+        });
+      } else if ((formType === INPUTS_TYPES.MULTIPLE_CHOICE || 
+                 formType === INPUTS_TYPES.SINGLE_CHOICE || 
+                 formType === INPUTS_TYPES.SELECT) && 
+                 (!field.options || !Array.isArray(field.options) || field.options.length === 0)) {
+        // Default options if none provided but field type requires them
+        choices = [
+          ['0', 'Option 1'],
+          ['1', 'Option 2'],
+          ['2', 'Option 3']
+        ];
+      }
+
+      // Determine primitive based on field type
+      let primitive = 'text';
+      if (formType === INPUTS_TYPES.MULTIPLE_CHOICE ||
+          formType === INPUTS_TYPES.SINGLE_CHOICE ||
+          formType === INPUTS_TYPES.SELECT) {
+        primitive = 'option';
+      } else if (formType === INPUTS_TYPES.NUMBER) {
+        primitive = 'number';
+      }
+
+      // Map to correct renderElement
+      const renderElement = mapTypeToRenderElement(formType);
+
+      // Additional settings for the field
+      const settings = {
+        required: !!field.required,
+        renderElement,
+        description: field.description || '',
+        placeholder: field.placeholder || '',
+        fieldId: fieldId,
+        defaultValue: undefined, // Add default property to the object
+      };
+
+      // Add default answer for required fields if specified
+      if (field.required && field.defaultValue) {
+        settings.defaultValue = field.defaultValue;
+      }
+
+      return generateQuestion(
+        primitive,
+        field.label || `Question ${index + 1}`,
+        choices,
+        settings
+      );
+    }) || [];
+
+    // Update the form with the generated questions
+    updateQuestionsList(convertedFields);
+    updateFormName(formName);
+
+    // Update form description
+    updateFormSetting({
+      ...formSettings,
+      description: formDescription
+    });
+  }
+};

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ConnectionStatus.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ConnectionStatus.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { Alert, Spin } from 'antd';
+import { Alert, Spin, Typography } from 'antd';
 import { ConnectionStatusProps } from './types';
+
+const { Text } = Typography;
 
 const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   loading,
   connectionStatus,
-  availableModels
+  availableModels,
+  error
 }) => {
   if (loading && connectionStatus === null) {
     return <Spin tip="Testing connection..." />;
@@ -13,13 +16,21 @@ const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
 
   if (connectionStatus !== null) {
     return (
-      <Alert
-        type={connectionStatus ? "success" : "error"}
-        message={connectionStatus ?
-          `Connected to Ollama with ${availableModels.length} model(s) available` :
-          "Could not connect to Ollama"}
-        showIcon
-      />
+      <>
+        <Alert
+          type={connectionStatus ? "success" : "error"}
+          message={connectionStatus ?
+            `Connected to Ollama with ${availableModels.length} model(s) available` :
+            "Could not connect to Ollama"}
+          showIcon
+        />
+        {!connectionStatus && error && error.includes('CORS') && (
+          <Text type="danger" style={{ display: 'block', marginTop: '8px' }}>
+            CORS error detected. If using an external server, ensure it allows cross-origin requests. 
+            You may need to configure CORS on the server or use a proxy.
+          </Text>
+        )}
+      </>
     );
   }
 

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ConnectionStatus.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ConnectionStatus.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Alert, Spin } from 'antd';
+import { ConnectionStatusProps } from './types';
+
+const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
+  loading,
+  connectionStatus,
+  availableModels
+}) => {
+  if (loading && connectionStatus === null) {
+    return <Spin tip="Testing connection..." />;
+  }
+
+  if (connectionStatus !== null) {
+    return (
+      <Alert
+        type={connectionStatus ? "success" : "error"}
+        message={connectionStatus ?
+          `Connected to Ollama with ${availableModels.length} model(s) available` :
+          "Could not connect to Ollama"}
+        showIcon
+      />
+    );
+  }
+
+  return null;
+};
+
+export default ConnectionStatus;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/FormGenerationPanel.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/FormGenerationPanel.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Select, Input, Button, Typography, Alert, Tooltip } from 'antd';
+import { FormGenerationPanelProps } from './types';
+import { InfoCircleOutlined } from '@ant-design/icons';
+
+const { TextArea } = Input;
+const { Text, Paragraph } = Typography;
+const { Option } = Select;
+
+const FormGenerationPanel: React.FC<FormGenerationPanelProps> = ({
+  formType,
+  setFormType,
+  formTypes,
+  prompt,
+  setPrompt,
+  onGenerate,
+  loading,
+  disabled,
+  error
+}) => {
+  const placeholdersByType = {
+    'survey': "Create a customer satisfaction survey with questions about service quality, product features, and overall satisfaction ratings.",
+    'contact': "Create a contact form for a web design agency that collects name, email, phone, project type, budget range, and project description.",
+    'registration': "Create a workshop registration form that collects attendee details, workshop preferences, and accommodates accessibility needs.",
+    'feedback': "Create a product feedback form with ratings for ease of use, reliability, customer support, and areas for improvement.",
+    'application': "Create a job application form for a software developer position with education, experience, and skills sections.",
+    'event': "Create an event registration form for a tech conference with session preferences, dietary requirements, and t-shirt size.",
+    'custom': "Create a form for [describe your purpose]..."
+  };
+
+  return (
+    <>
+      <div>
+        <Text>Form Type</Text>
+        <Select
+          style={{ width: '100%' }}
+          value={formType}
+          onChange={(value) => {
+            setFormType(value);
+            // When form type changes, set a helpful placeholder
+            if (!prompt || prompt === placeholdersByType[formType as keyof typeof placeholdersByType]) {
+              setPrompt('');
+            }
+          }}
+        >
+          {formTypes.map(type => (
+            <Option key={type.value} value={type.value}>{type.label}</Option>
+          ))}
+        </Select>
+      </div>
+
+      <div className="prompt-input">
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+          <Text>Describe the form you want to create</Text>
+          <Tooltip title="Be specific about fields, validation, and any special requirements. The more details you provide, the better the form will match your needs.">
+            <InfoCircleOutlined style={{ marginLeft: 8 }} />
+          </Tooltip>
+        </div>
+
+        <TextArea
+          rows={4}
+          placeholder={placeholdersByType[formType as keyof typeof placeholdersByType] || "Describe your form requirements..."}
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+        />
+
+        <div style={{ textAlign: 'right', marginTop: 4 }}>
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              const examples = {
+                'survey': "Create a detailed customer satisfaction survey for an e-commerce website with sections for product quality, website usability, and delivery experience. Include open-ended feedback questions. Make the name, email and overall satisfaction rating required fields.",
+                'contact': "Create a comprehensive contact form for a marketing agency that collects full name, email, phone number, company size, budget range, service interests (multiple choice from: SEO, Content Marketing, Social Media, PPC), project timeline, and how they heard about us. The name, email and service interests should be required fields.",
+                'registration': "Create a coding bootcamp application form that collects personal information, programming experience level (none, beginner, intermediate, advanced), preferred programming languages (multiple selection), learning goals, and availability for different course schedules. Make email, experience level and availability required.",
+                'feedback': "Create a detailed restaurant feedback form with sections for food quality, service, ambiance, and value for money using 5-star ratings. Include fields for specific dishes ordered, wait time, server name, and open-ended suggestions for improvement. The overall rating and visit date should be required.",
+                'application': "Create an internship application form for a tech company with fields for personal details, education history, relevant skills (multiple choice), programming languages known (multiple selection), availability dates, and a personal statement section. All fields except for the personal statement should be required.",
+                'event': "Create a conference registration form with attendee information, session track preferences (choose from: Technical, Business, Design, Leadership), meal preferences (vegetarian, vegan, no restrictions, other), t-shirt size, and special accommodation needs. Name, email and session track are required fields.",
+                'custom': "Create a neighborhood community garden plot request form with applicant details, plot size preference (small, medium, large), gardening experience level, preferred location in the garden (dropdown with north, south, east, west options), willingness to volunteer hours, and specific plants they intend to grow. Make the contact information and volunteer hours commitment required fields."
+              };
+
+              setPrompt(examples[formType as keyof typeof examples] || examples['custom']);
+            }}
+          >
+            Load example prompt
+          </Button>
+        </div>
+
+        <Paragraph type="secondary" style={{ fontSize: '12px', marginTop: 4 }}>
+          Include details about required fields, field types, and validation rules for best results.
+        </Paragraph>
+      </div>
+
+      <Button
+        type="primary"
+        block
+        onClick={onGenerate}
+        loading={loading}
+        disabled={disabled || !prompt.trim()}
+      >
+        Generate Form
+      </Button>
+
+      {error && (
+        <Alert type="error" message={error} showIcon />
+      )}
+    </>
+  );
+};
+
+export default FormGenerationPanel;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ModelSelector.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ModelSelector.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Select, Button, Typography, Spin, Empty } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { ModelSelectorProps } from './types';
+
+const { Text } = Typography;
+const { Option } = Select;
+
+const ModelSelector: React.FC<ModelSelectorProps> = ({
+  model,
+  setModel,
+  availableModels,
+  fetchingModels,
+  fetchModels
+}) => {
+  return (
+    <div>
+      <div className="model-select-header">
+        <Text>Model</Text>
+        <Button
+          type="link"
+          icon={<ReloadOutlined />}
+          onClick={fetchModels}
+          loading={fetchingModels}
+          className="reload-button"
+        >
+          Refresh
+        </Button>
+      </div>
+      
+      <Select
+        style={{ width: '100%' }}
+        value={model}
+        onChange={setModel}
+        loading={fetchingModels}
+        notFoundContent={availableModels.length === 0 ?
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No models found" /> :
+          <Spin size="small" />}
+      >
+        {availableModels.map(model => (
+          <Option key={model.name} value={model.name}>{model.name}</Option>
+        ))}
+      </Select>
+      
+      {availableModels.length === 0 && !fetchingModels && (
+        <Text type="secondary" style={{ display: 'block', fontSize: '12px', marginTop: '4px' }}>
+          No models found. Connect to Ollama server to fetch available models.
+        </Text>
+      )}
+    </div>
+  );
+};
+
+export default ModelSelector;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/OllamaSettings.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/OllamaSettings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Input, Button, Space, Typography} from 'antd';
+import { OllamaSettingsProps } from './types';
+
+const { Text } = Typography;
+
+const OllamaSettings: React.FC<OllamaSettingsProps> = ({
+  ollamaUrl,
+  onUrlChange,
+  onTestConnection,
+  onSaveSettings,
+  loading,
+  connectionStatus
+}) => {
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <div>
+        <Text>Ollama Server URL</Text>
+        <Input
+          placeholder="http://localhost:11434"
+          value={ollamaUrl}
+          onChange={onUrlChange}
+        />
+      </div>
+
+      <div className="action-buttons">
+        <Button 
+          onClick={onTestConnection} 
+          loading={loading && connectionStatus === null}
+        >
+          Test Connection
+        </Button>
+        <Button type="primary" onClick={onSaveSettings}>
+          Save Settings
+        </Button>
+      </div>
+    </Space>
+  );
+};
+
+export default OllamaSettings;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ResponsePreview.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/ResponsePreview.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Spin, Typography } from 'antd';
+import { ResponsePreviewProps } from './types';
+
+const { Text } = Typography;
+
+const ResponsePreview: React.FC<ResponsePreviewProps> = ({
+  loading,
+  generationResponse,
+  error
+}) => {
+  if (loading) {
+    return (
+      <div className="loading-container">
+        <Spin tip="Generating form..." size="large" />
+        <Text style={{ display: 'block', marginTop: 16 }}>
+          This might take a moment depending on your model and hardware.
+        </Text>
+      </div>
+    );
+  }
+
+  if (generationResponse) {
+    return (
+      <>
+        <Text strong>Response Preview:</Text>
+        <div className="response-preview">
+          {generationResponse}
+        </div>
+      </>
+    );
+  }
+
+  return null;
+};
+
+export default ResponsePreview;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/index.tsx
@@ -99,9 +99,9 @@ const AIFormGenerator: React.FC<AIFormGeneratorProps> = ({
 
     try {
       const isConnected = await ollamaService.testConnection();
-      setConnectionStatus(isConnected);
+      setConnectionStatus(isConnected.success);
 
-      if (isConnected) {
+      if (isConnected.success) {
         // Update available models after successful connection
         const models = ollamaService.getAvailableModels();
         setAvailableModels(models);
@@ -204,6 +204,7 @@ const AIFormGenerator: React.FC<AIFormGeneratorProps> = ({
               loading={loading}
               connectionStatus={connectionStatus}
               availableModels={availableModels}
+              error={error}
             />
           </Space>
         </>

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/index.tsx
@@ -1,0 +1,237 @@
+import React, { useState, useEffect } from 'react';
+import { Divider, Typography, Space } from 'antd';
+import { ollamaService } from '../../services/ollamaService';
+import useFormBuilderContext from '../../hooks/useFormBuilderContext';
+import { StyledContainer } from './styles';
+import { FormTypeOption } from './types';
+import OllamaSettings from './OllamaSettings';
+import ModelSelector from './ModelSelector';
+import ConnectionStatus from './ConnectionStatus';
+import FormGenerationPanel from './FormGenerationPanel';
+import ResponsePreview from './ResponsePreview';
+import { processAIResponse } from './AIProcessor';
+
+const { Title } = Typography;
+
+export interface AIFormGeneratorProps {
+  className?: string;
+  hideSettings?: boolean;
+  initialPrompt?: string;
+  initialResponse?: string | null;
+  initialFormType?: string;
+  onFormGenerated?: (prompt: string, response: string, formType: string) => void;
+}
+
+const formTypes: FormTypeOption[] = [
+  { value: 'survey', label: 'Survey Form' },
+  { value: 'contact', label: 'Contact Form' },
+  { value: 'registration', label: 'Registration Form' },
+  { value: 'feedback', label: 'Feedback Form' },
+  { value: 'application', label: 'Application Form' },
+  { value: 'event', label: 'Event Registration' },
+  { value: 'custom', label: 'Custom Form' },
+];
+
+const AIFormGenerator: React.FC<AIFormGeneratorProps> = ({
+  className,
+  hideSettings = false,
+  initialPrompt = '',
+  initialResponse = null,
+  initialFormType = 'survey',
+  onFormGenerated
+}) => {
+  // Ollama configuration states
+  const [ollamaUrl, setOllamaUrl] = useState(ollamaService.getConfig().baseUrl);
+  const [model, setModel] = useState(ollamaService.getConfig().model);
+  const [availableModels, setAvailableModels] = useState(ollamaService.getAvailableModels());
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<boolean | null>(null);
+
+  // Form generation states
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [formType, setFormType] = useState(initialFormType);
+  const [loading, setLoading] = useState(false);
+  const [generationResponse, setGenerationResponse] = useState<string | null>(initialResponse);
+  const [error, setError] = useState<string | null>(null);
+
+  const formContext = useFormBuilderContext();
+
+  // Update state when initial props change
+  useEffect(() => {
+    setPrompt(initialPrompt);
+    setGenerationResponse(initialResponse);
+    setFormType(initialFormType);
+  }, [initialPrompt, initialResponse, initialFormType]);
+
+  // Initial fetch of available models
+  useEffect(() => {
+    fetchModels();
+  }, []);
+
+  const fetchModels = async () => {
+    setFetchingModels(true);
+    try {
+      const models = await ollamaService.fetchAvailableModels();
+      setAvailableModels(models);
+
+      // If we have models and current selection isn't among them, select first available
+      if (models.length > 0) {
+        const modelNames = models.map(m => m.name);
+        if (!modelNames.includes(model)) {
+          setModel(models[0].name);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch models", error);
+    } finally {
+      setFetchingModels(false);
+    }
+  };
+
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setOllamaUrl(e.target.value);
+  };
+
+  const handleTestConnection = async () => {
+    ollamaService.setConfig({ baseUrl: ollamaUrl });
+    setConnectionStatus(null);
+    setLoading(true);
+
+    try {
+      const isConnected = await ollamaService.testConnection();
+      setConnectionStatus(isConnected);
+
+      if (isConnected) {
+        // Update available models after successful connection
+        const models = ollamaService.getAvailableModels();
+        setAvailableModels(models);
+
+        // Update selected model if needed
+        if (models.length > 0) {
+          const modelNames = models.map(m => m.name);
+          if (!modelNames.includes(model)) {
+            setModel(models[0].name);
+          }
+        }
+      }
+    } catch (error) {
+      setConnectionStatus(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveSettings = () => {
+    ollamaService.setConfig({ baseUrl: ollamaUrl, model });
+  };
+
+  const handleGenerate = async () => {
+    if (!prompt.trim()) {
+      setError('Please enter a prompt');
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+    setGenerationResponse(null);
+
+    try {
+      const request = {
+        prompt,
+        formType,
+        temperature: 0.7
+      };
+
+      const response = await ollamaService.generateForm(request);
+
+      if (response.success && response.fields) {
+        // Display the raw response
+        const responseStr = JSON.stringify(response.fields, null, 2);
+        setGenerationResponse(responseStr);
+
+        // Process the response and update the form
+        await processAIResponse(response, prompt, {
+          formSettings: formContext.formSettings,
+          updateFormSetting: formContext.updateFormSetting,
+          updateQuestionsList: formContext.updateQuestionsList,
+          updateFormName: formContext.updateFormName
+        });
+        
+        // Notify parent that form was generated successfully
+        if (onFormGenerated) {
+          onFormGenerated(prompt, responseStr, formType);
+        }
+      } else {
+        setError(response.error || 'Failed to generate form');
+        if (response.rawResponse) {
+          setGenerationResponse(response.rawResponse);
+        }
+      }
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <StyledContainer className={className}>
+      <Title level={4}>AI Form Generator</Title>
+
+      {!hideSettings && (
+        <>
+          <Divider />
+          <Title level={5}>Ollama Settings</Title>
+          <OllamaSettings
+            ollamaUrl={ollamaUrl}
+            onUrlChange={handleUrlChange}
+            onTestConnection={handleTestConnection}
+            onSaveSettings={handleSaveSettings}
+            loading={loading}
+            connectionStatus={connectionStatus}
+          />
+
+          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <ModelSelector
+              model={model}
+              setModel={setModel}
+              availableModels={availableModels}
+              fetchingModels={fetchingModels}
+              fetchModels={fetchModels}
+            />
+
+            <ConnectionStatus
+              loading={loading}
+              connectionStatus={connectionStatus}
+              availableModels={availableModels}
+            />
+          </Space>
+        </>
+      )}
+
+      <Divider />
+      <Title level={5}>Generate Form</Title>
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <FormGenerationPanel
+          formType={formType}
+          setFormType={setFormType}
+          formTypes={formTypes}
+          prompt={prompt}
+          setPrompt={setPrompt}
+          onGenerate={handleGenerate}
+          loading={loading}
+          disabled={availableModels.length === 0}
+          error={error}
+        />
+
+        <ResponsePreview
+          loading={loading}
+          generationResponse={generationResponse}
+          error={error}
+        />
+      </Space>
+    </StyledContainer>
+  );
+};
+
+export default AIFormGenerator;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/styles.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/styles.ts
@@ -1,0 +1,49 @@
+import { styled } from 'styled-components';
+
+export const StyledContainer = styled.div`
+  
+  .prompt-input {
+    margin-bottom: 16px;
+  }
+  
+  .generation-options {
+    margin-bottom: 16px;
+  }
+  
+  .action-buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+  
+  .loading-container {
+    text-align: center;
+    padding: 24px;
+  }
+  
+  .response-preview {
+    max-height: 200px;
+    overflow-y: auto;
+    background: #f5f5f5;
+    padding: 12px;
+    border-radius: 4px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+    white-space: pre-wrap;
+    font-family: monospace;
+    font-size: 12px;
+  }
+  
+  .model-select-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+  }
+  
+  .reload-button {
+    font-size: 14px;
+    padding: 0;
+    height: auto;
+  }
+`;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/types.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/types.ts
@@ -27,6 +27,7 @@ export interface ConnectionStatusProps {
   loading: boolean;
   connectionStatus: boolean | null;
   availableModels: OllamaModel[];
+  error: string | null;
 }
 
 export interface FormGenerationPanelProps {

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/types.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormGenerator/types.ts
@@ -1,0 +1,55 @@
+import { OllamaModel } from "../../services/ollamaService";
+import { IFormSettings } from "../FormSettings/types";
+
+export interface FormTypeOption {
+  value: string;
+  label: string;
+}
+
+export interface OllamaSettingsProps {
+  ollamaUrl: string;
+  onUrlChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onTestConnection: () => void;
+  onSaveSettings: () => void;
+  loading: boolean;
+  connectionStatus: boolean | null;
+}
+
+export interface ModelSelectorProps {
+  model: string;
+  setModel: (model: string) => void;
+  availableModels: OllamaModel[];
+  fetchingModels: boolean;
+  fetchModels: () => void;
+}
+
+export interface ConnectionStatusProps {
+  loading: boolean;
+  connectionStatus: boolean | null;
+  availableModels: OllamaModel[];
+}
+
+export interface FormGenerationPanelProps {
+  formType: string;
+  setFormType: (type: string) => void;
+  formTypes: FormTypeOption[];
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  onGenerate: () => void;
+  loading: boolean;
+  disabled: boolean;
+  error: string | null;
+}
+
+export interface ResponsePreviewProps {
+  loading: boolean;
+  generationResponse: string | null;
+  error: string | null;
+}
+
+export interface AIProcessingProps {
+  formSettings: IFormSettings;
+  updateFormSetting: (settings: IFormSettings) => void;
+  updateQuestionsList: (fields: any[]) => void;
+  updateFormName: (name: string) => void;
+}

--- a/packages/formstr-app/src/containers/CreateFormNew/components/AIFormMenu/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/AIFormMenu/index.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { Button, Modal } from "antd";
+import { RobotOutlined } from "@ant-design/icons";
+import AIFormGenerator from "../AIFormGenerator";
+
+function AIFormMenu() {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [showSettings, setShowSettings] = useState(false);
+    // Store form generation data to persist between modal sessions
+    const [savedPrompt, setSavedPrompt] = useState('');
+    const [savedResponse, setSavedResponse] = useState<string | null>(null);
+    const [savedFormType, setSavedFormType] = useState('survey');
+
+    const handleOpenModal = () => setIsModalOpen(true);
+    const handleCloseModal = () => {
+        setIsModalOpen(false);
+        setShowSettings(false); // Reset settings visibility when closing
+    };
+    const toggleSettings = () => setShowSettings(!showSettings);
+
+    // Handle successful form generation
+    const handleFormGenerated = (prompt: string, response: string, formType: string) => {
+        // Save the current values
+        setSavedPrompt(prompt);
+        setSavedResponse(response);
+        setSavedFormType(formType);
+        
+        // Auto-close the modal
+        setIsModalOpen(false);
+    };
+
+    return (
+        <>
+            <div style={{ padding: "10px" }}>
+                <Button
+                    type="primary"
+                    icon={<RobotOutlined />}
+                    onClick={handleOpenModal}
+                >
+                    Generate with AI
+                </Button>
+            </div>
+
+            <Modal
+                title="AI Form Generator"
+                open={isModalOpen}
+                onCancel={handleCloseModal}
+                width={700}
+                footer={null}
+                destroyOnClose={false}
+            >
+                <Button onClick={toggleSettings}>
+                    {showSettings ? 'Hide Settings' : 'Show Settings'}
+                </Button>
+                <AIFormGeneratorWrapper 
+                    showSettings={showSettings}
+                    initialPrompt={savedPrompt}
+                    initialResponse={savedResponse}
+                    initialFormType={savedFormType}
+                    onFormGenerated={handleFormGenerated}
+                />
+            </Modal>
+        </>
+    );
+}
+
+// Wrapper component to handle showing/hiding settings
+const AIFormGeneratorWrapper = ({ 
+    showSettings, 
+    initialPrompt,
+    initialResponse,
+    initialFormType,
+    onFormGenerated
+}: { 
+    showSettings: boolean,
+    initialPrompt: string,
+    initialResponse: string | null,
+    initialFormType: string,
+    onFormGenerated: (prompt: string, response: string, formType: string) => void
+}) => {
+    return (
+        <AIFormGenerator 
+            hideSettings={!showSettings} 
+            initialPrompt={initialPrompt}
+            initialResponse={initialResponse}
+            initialFormType={initialFormType}
+            onFormGenerated={onFormGenerated}
+        />
+    );
+};
+
+export default AIFormMenu;

--- a/packages/formstr-app/src/containers/CreateFormNew/components/Sidebar/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/Sidebar/index.tsx
@@ -4,6 +4,7 @@ import BasicMenu from "../BasicMenu";
 import InputsMenu from "../InputsMenu";
 import PreBuiltMenu from "../PreBuiltMenu";
 import Sidebar from "../../../../components/Sidebar";
+import AIFormMenu from "../AIFormMenu";
 
 // TODO: remove usage of any here
 function SidebarMenu(_props: any, ref: any) {
@@ -14,6 +15,8 @@ function SidebarMenu(_props: any, ref: any) {
       <InputsMenu />
       <Divider className="menu-divider" />
       <PreBuiltMenu />
+      <Divider className="menu-divider" />
+      <AIFormMenu />
     </Sidebar>
   );
 }

--- a/packages/formstr-app/src/containers/CreateFormNew/components/Validation/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/Validation/index.tsx
@@ -20,8 +20,6 @@ function Validation(props: IProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answerType]);
 
-  // Fix: Safely check if ANSWER_TYPE_RULES_MENU has the answerType
-  // if (!selected.length && (!ANSWER_TYPE_RULES_MENU[answerType] || !ANSWER_TYPE_RULES_MENU[answerType].length))
   if (!selected.length && !ANSWER_TYPE_RULES_MENU[answerType].length)
     return null;
 

--- a/packages/formstr-app/src/containers/CreateFormNew/components/Validation/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/Validation/index.tsx
@@ -20,6 +20,8 @@ function Validation(props: IProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answerType]);
 
+  // Fix: Safely check if ANSWER_TYPE_RULES_MENU has the answerType
+  // if (!selected.length && (!ANSWER_TYPE_RULES_MENU[answerType] || !ANSWER_TYPE_RULES_MENU[answerType].length))
   if (!selected.length && !ANSWER_TYPE_RULES_MENU[answerType].length)
     return null;
 

--- a/packages/formstr-app/src/containers/CreateFormNew/providers/FormBuilder/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/providers/FormBuilder/index.tsx
@@ -257,6 +257,10 @@ export default function FormBuilderProvider({
     setViewKey(form.viewKey);
   };
 
+  const updateFormName = (name: string) => {
+    setFormName(name);
+  };
+
   return (
     <FormBuilderContext.Provider
       value={{

--- a/packages/formstr-app/src/containers/CreateFormNew/services/ollamaService.ts
+++ b/packages/formstr-app/src/containers/CreateFormNew/services/ollamaService.ts
@@ -1,0 +1,199 @@
+import axios from 'axios';
+
+export interface OllamaConfig {
+  baseUrl: string;
+  model: string;
+}
+
+export interface OllamaModel {
+  name: string;
+  size: number;
+  modifiedAt: string;
+  digest: string;
+}
+
+export interface GenerationRequest {
+  prompt: string;
+  formType?: string;
+  temperature?: number;
+}
+
+export interface GenerationResponse {
+  success: boolean;
+  fields?: Array<any>;
+  error?: string;
+  rawResponse?: string;
+  formName?: string;
+  description?: string;
+}
+
+export const defaultOllamaConfig: OllamaConfig = {
+  baseUrl: 'http://localhost:11434',
+  model: 'llama3'
+};
+
+class OllamaService {
+  private config: OllamaConfig = defaultOllamaConfig;
+  private availableModels: OllamaModel[] = [];
+
+  setConfig(config: Partial<OllamaConfig>) {
+    this.config = { ...this.config, ...config };
+  }
+
+  getConfig(): OllamaConfig {
+    return this.config;
+  }
+
+  getAvailableModels(): OllamaModel[] {
+    return this.availableModels;
+  }
+
+  async fetchAvailableModels(): Promise<OllamaModel[]> {
+    try {
+      const response = await axios.get(`${this.config.baseUrl}/api/tags`);
+      if (response.data && response.data.models) {
+        this.availableModels = response.data.models;
+
+        // If current model isn't in the list, set to first available one
+        if (this.availableModels.length > 0) {
+          const modelNames = this.availableModels.map(model => model.name);
+          if (!modelNames.includes(this.config.model)) {
+            this.config.model = this.availableModels[0].name;
+          }
+        }
+
+        return this.availableModels;
+      }
+      return [];
+    } catch (error) {
+      console.error("Failed to fetch Ollama models:", error);
+      this.availableModels = [];
+      return [];
+    }
+  }
+
+  async generateForm(request: GenerationRequest): Promise<GenerationResponse> {
+    try {
+      const systemPrompt = `You are a form creation assistant specialized in creating web forms.
+      
+      Create a JSON structure for a ${request.formType || "general"} form with the following format:
+      
+      {
+        "fields": [
+          {
+            "id": "unique_string_id",
+            "type": "FIELD_TYPE",
+            "label": "Question text",
+            "required": boolean,
+            "description": "Optional help text for the field",
+            "placeholder": "Optional placeholder text",
+            "options": ["Option 1", "Option 2", "Option 3"] // Only for multiple-choice, single-choice, or dropdown fields
+          },
+          // More fields...
+        ],
+        "formName": "Form name based on the prompt",
+        "description": "A comprehensive description for the form"
+      }
+      
+      SUPPORTED FIELD TYPES (use these exact strings):
+      - "short_text" - For short text responses
+      - "paragraph" - For longer text responses
+      - "number" - For numerical input
+      - "multiple_choice" - For checkbox selection (multiple answers)
+      - "single_choice" - For radio button selection (one answer)
+      - "dropdown" - For dropdown selection
+      - "date" - For date selection
+      - "time" - For time selection
+      
+      IMPORTANT RULES:
+      1. For required fields, provide sensible default or example answers
+      2. Always include a form description that summarizes the purpose of the form
+      3. For multiple_choice, single_choice, and dropdown fields, always provide an "options" array with at least 2-5 choices
+      4. Each field must have a unique ID
+      5. Return ONLY valid JSON
+      `;
+
+      const response = await axios.post(`${this.config.baseUrl}/api/generate`, {
+        model: this.config.model,
+        prompt: request.prompt,
+        system: systemPrompt,
+        stream: false,
+        temperature: request.temperature || 0.7,
+        format: "json"
+      });
+
+      // Add this to the generateForm method right after the axios.post call
+      if (response.data) {
+        try {
+          // Parse the model's output to extract JSON
+          const jsonMatch = response.data.response.match(/```json\s*([\s\S]*?)\s*```/) ||
+            response.data.response.match(/({[\s\S]*})/) ||
+            [null, response.data.response];
+
+          const jsonContent = jsonMatch[1];
+          const parsedResponse = JSON.parse(jsonContent);
+
+          // Create a standardized response object
+          const result = {
+            success: true,
+            fields: parsedResponse.fields || [],
+            formName: parsedResponse.formName || undefined,
+            description: parsedResponse.description || undefined,
+            rawResponse: response.data.response
+          };
+
+          // Ensure every field has proper options array
+          if (result.fields) {
+            result.fields = result.fields.map((field: any, index: number) => {
+              // Ensure field has an ID
+              if (!field.id) field.id = `field_${index}`;
+
+              // For choice fields, ensure options are properly formatted
+              if ((field.type === 'multiple_choice' || field.type === 'single_choice' || field.type === 'dropdown') &&
+                (!field.options || !Array.isArray(field.options))) {
+                field.options = ['Option 1', 'Option 2', 'Option 3'];
+              }
+
+              return field;
+            });
+          }
+
+          return result;
+        } catch (parseError) {
+          console.error("Failed to parse Ollama response", parseError);
+          return {
+            success: false,
+            error: "Failed to parse AI response",
+            rawResponse: response.data.response
+          };
+        }
+      }
+
+      return { success: false, error: "No response from Ollama" };
+    } catch (error) {
+      console.error("Ollama API error:", error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error connecting to Ollama"
+      };
+    }
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      const response = await axios.get(`${this.config.baseUrl}/api/version`);
+      if (response.data) {
+        // After successful connection, fetch available models
+        await this.fetchAvailableModels();
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error("Ollama connection test failed:", error);
+      return false;
+    }
+  }
+}
+
+export const ollamaService = new OllamaService();
+export default ollamaService;


### PR DESCRIPTION
This is a draft pull request for integrating Ollama in Formstr. Currently, I have implemented the following:

- Allows users to describe the form they need in plain English.
- Sends the user's request to the Ollama API with specific instructions.
- Processes the AI's response to create the app's form structure.
- Maps types to convert between AI field types and formstr-specific types.
- Manages special field configurations, such as required fields and options for choice fields.
- Updates the form builder with the generated fields and settings.
- Handles connection management for the local Ollama server.
- user-friendly interface with a settings panel, form type selector, and example prompts.

I am using the Lama 3.1 8B model and have added proper error handling. I was unable to check with a server URL, so please verify if it is working. Additionally, adding an answer to a question is yet to be implemented.

https://github.com/user-attachments/assets/8ef315c7-2094-4045-ac7f-482ab2d44b15



@abh3po, please take a look at this whenever you have some time.
