### PR TITLE
Added few alert for Publish Page

### DIFF
--- a/packages/formstr-app/src/containers/CreateFormNew/components/Header/Header.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export const CreateFormHeader: React.FC = () => {
       return;
     }
     if(!formName){
-      alert("Form name is required");
+      alert("Form title is required");
       return;
     }
     setIsPostPublishModalOpen(true);

--- a/packages/formstr-app/src/containers/CreateFormNew/components/Header/Header.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/Header/Header.tsx
@@ -15,7 +15,7 @@ export const CreateFormHeader: React.FC = () => {
 
   const { Header } = Layout;
   const { Text } = Typography;
-  const { saveForm, setSelectedTab, formSettings, relayList } =
+  const { saveForm, setSelectedTab, formSettings, relayList, questionsList, formName } =
     useFormBuilderContext();
 
   const onClickHandler: MenuProps["onClick"] = (e) => {
@@ -27,7 +27,18 @@ export const CreateFormHeader: React.FC = () => {
       alert("Form ID is required");
       return;
     }
-
+    if(!questionsList.length){
+      alert("Form has no questions");
+      return;
+    }
+    if(!formSettings?.description){
+      alert("Form description is required");
+      return;
+    }
+    if(!formName){
+      alert("Form name is required");
+      return;
+    }
     setIsPostPublishModalOpen(true);
     setAcceptedRelays([]);
 

--- a/packages/formstr-app/src/templates/blank.ts
+++ b/packages/formstr-app/src/templates/blank.ts
@@ -9,9 +9,9 @@ export const blankTemplate: FormTemplate = {
   name: 'Blank Form',
   description: 'Start with a clean slate.',
   initialState: {
-    formName: 'Untitled Form',
+    formName: 'Form Title',
     formSettings: {
-      description: 'description here',
+      description: 'Form description',
       thankYouPage: true,
       notifyNpubs: [],
       publicForm: true,


### PR DESCRIPTION
solves Issue : #284

<img width="1425" alt="Screenshot 2025-04-18 at 2 15 25 AM" src="https://github.com/user-attachments/assets/6d8c607b-2782-4c79-b2ae-b51226eb6a57" />

```
added no question alert 
```

<img width="1425" alt="Screenshot 2025-04-18 at 2 18 36 AM" src="https://github.com/user-attachments/assets/befe1529-5b4f-4b9f-bbf1-066b61a1c5bc" />

```
added no title alert
```

<img width="1434" alt="Screenshot 2025-04-18 at 2 15 38 AM" src="https://github.com/user-attachments/assets/5a9ab851-5e5b-48bb-8034-fd842620b507" />

```
added no description alert 
```


also changed the blank template text as when user tries to create new form , user ideally chooses from template 
and if we directly hit [link](https://formstr.app/#/c)  then only we see title as "This is the title of your form! Tap to edit."  and description as "This is the description, you can use markdown while editing it! tap anywhere on the form to edit, including this description." we can see these unless we hit the link


so changed it for better understanding when user starts from black template .