### PR TITLE
added Behavioral test

### DIFF
--- a/packages/formstr-app/jest.config.js
+++ b/packages/formstr-app/jest.config.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { useESM: true }],
+  },
+};

--- a/packages/formstr-app/package.json
+++ b/packages/formstr-app/package.json
@@ -8,19 +8,21 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^29.5.5",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.7.0",
     "@types/react": "^18.2.23",
     "@types/react-dom": "^18.2.8",
     "antd": "^5.11.2",
     "dayjs": "^1.11.10",
     "framer-motion": "^10.16.15",
+    "jest": "^29.7.0",
     "nostr-tools": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.1",
+    "ts-jest": "^29.3.2",
     "typescript": "^5.2.2",
     "url": "^0.11.3",
     "web-vitals": "^2.1.4",
@@ -33,7 +35,8 @@
     "start": "react-scripts start",
     "prebuild": "yarn workspace @formstr/sdk build",
     "build": "react-scripts build && cp -r \".well-known\" build/ && cp _config.yml build/ && cp .nojekyll build/",
-    "test": "react-scripts test",
+    "test": "jest",
+    "test:react": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix"
@@ -49,7 +52,8 @@
     "@tsconfig/create-react-app": "^2.0.1",
     "@types/styled-components": "^5.1.34",
     "gh-pages": "^6.0.0",
-    "react-router-dom": "^6.15.0"
+    "react-router-dom": "^6.15.0",
+    "ws": "^8.18.1"
   },
   "browserslist": {
     "production": [

--- a/packages/formstr-app/src/formLifecycle.test.ts
+++ b/packages/formstr-app/src/formLifecycle.test.ts
@@ -1,0 +1,139 @@
+import { Event, SimplePool, generateSecretKey, getPublicKey } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
+import { createForm } from './nostr/createForm';
+import { sendResponses } from './nostr/common';
+import { fetchFormResponses } from './nostr/responses';
+import { Response, Tag } from './nostr/types';
+
+const TEST_RELAYS = ['wss://relay.damus.io/', 'wss://nos.lol'];
+// timeout for relay operations
+jest.setTimeout(30000); 
+
+describe('Form Lifecycle Behavioral Test', () => {
+  let pool: SimplePool;
+  let formSecretKey: string;
+  let formPublicKey: string;
+  let formId: string;
+
+  beforeAll(() => {
+    pool = new SimplePool();
+    const secretKeyBytes = generateSecretKey();
+    formSecretKey = bytesToHex(secretKeyBytes);
+    formPublicKey = getPublicKey(secretKeyBytes);
+    formId = `test-form-${Date.now()}`;
+  });
+
+  afterAll(() => {
+    if (pool) {
+      pool.close(TEST_RELAYS);
+    }
+  });
+
+  test('should publish a form, fetch it, submit responses, and verify visibility', async () => {
+    const formTags: Tag[] = [
+      ["d", formId],
+      ["name", "Sanity Check Test Form"],
+      ["field", "q1", "shortText", "What is your name?", "{}"],
+      ["field", "q2", "paragraph", "Tell us about yourself", "{}"],
+      ["settings", JSON.stringify({ public: true })]
+    ];
+
+    // Create and publish the form
+    const result = await createForm(
+      formTags,
+      TEST_RELAYS,
+      new Set<string>(), 
+      new Set<string>(), 
+      false, 
+      (url: string) => console.log(`Form accepted by relay: ${url}`),
+      formSecretKey
+    );
+
+    expect(result).toBeDefined();
+    expect(result.acceptedRelays).toBeDefined();
+    expect(Array.isArray(result.acceptedRelays)).toBe(true);
+    expect(result.acceptedRelays.length).toBeGreaterThan(0);
+
+    // Wait for form to propagate
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Verify we can find the published form
+    let formFound = false;
+    await new Promise<void>((resolve) => {
+      const sub = pool.subscribeMany(
+        TEST_RELAYS,
+        [{ kinds: [30168], authors: [formPublicKey] }],
+        {
+          onevent: (event) => {
+            if (event.pubkey === formPublicKey &&
+                event.tags.some(tag => tag[0] === "d" && tag[1] === formId)) {
+              formFound = true;
+              sub.close();
+              if (timeoutId) clearTimeout(timeoutId);
+              resolve();
+            }
+          }
+        }
+      );
+
+      // timeout to resolve if form isn't found
+      const timeoutId = setTimeout(() => {
+        sub.close();
+        resolve();
+      }, 5000);
+    });
+
+    expect(formFound).toBe(true);
+
+    // Submit responses
+    const responderSecretKey = generateSecretKey();
+    const responses: Response[] = [
+      ["response", "q1", "Test User", ""],
+      ["response", "q2", "This is a test response for the sanity check.", ""]
+    ];
+
+    // Submit the responses
+    const sendResult = await sendResponses(
+      formPublicKey,
+      formId,
+      responses,
+      responderSecretKey,
+      false,
+      TEST_RELAYS,
+      (url: string) => console.log(`Response accepted by relay: ${url}`)
+    );
+
+    // Allow time for response to propagate
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Check for responses
+    let responseReceived = false;
+    await new Promise<void>((resolve) => {
+      const closer = fetchFormResponses(
+        formPublicKey,
+        formId,
+        pool,
+        (event: Event) => {
+          if (event.tags.some(tag =>
+              tag[0] === "a" &&
+              tag[1] === `30168:${formPublicKey}:${formId}`)) {
+            responseReceived = true;
+            closer.close();
+            if (timeoutId) clearTimeout(timeoutId);
+            resolve();
+          }
+        },
+        undefined,
+        TEST_RELAYS
+      );
+
+      // timeout to resolve if no responses found
+      const timeoutId = setTimeout(() => {
+        closer.close();
+        resolve();
+      }, 5000);
+    });
+
+    expect(responseReceived).toBe(true);
+  });
+});

--- a/packages/formstr-app/src/setupTests.js
+++ b/packages/formstr-app/src/setupTests.js
@@ -1,5 +1,30 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+require("@testing-library/jest-dom");
+
+if (typeof global.crypto === 'undefined') {
+  const { webcrypto } = require('crypto');
+  global.crypto = webcrypto;
+}
+
+if (typeof global.WebSocket === 'undefined') {
+  try {
+    global.WebSocket = require('ws');
+  } catch (e) {
+    console.warn('ws package not installed. Install it with "npm install --save-dev ws" for WebSocket support in tests.');
+  }
+}
+
+if (typeof global.MessageChannel === 'undefined') {
+  try {
+    global.MessageChannel = require('worker_threads').MessageChannel;
+  } catch (e) {
+    console.warn('worker_threads.MessageChannel not available. Some packages may not work as expected.');
+  }
+}
+
+const { TextEncoder, TextDecoder } = require('util');
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,10 +2516,18 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^29.5.5":
+"@types/jest@*":
   version "29.5.7"
   resolved "https://registry.npmjs.org/@types/jest/-/jest-29.5.7.tgz"
   integrity sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
+"@types/jest@^29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -3755,7 +3763,7 @@ browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.18.1, browserslist@^4
     node-releases "^2.0.13"
     update-browserslist-db "^1.0.13"
 
-bs-logger@0.x:
+bs-logger@0.x, bs-logger@^0.2.6:
   version "0.2.6"
   resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz"
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
@@ -4829,6 +4837,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
+ejs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
+  dependencies:
+    jake "^10.8.5"
 
 ejs@^3.1.6:
   version "3.1.9"
@@ -7512,7 +7527,7 @@ jest@^27.4.3:
 
 jest@^29.7.0:
   version "29.7.0"
-  resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
     "@jest/core" "^29.7.0"
@@ -7878,7 +7893,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -10539,6 +10554,11 @@ semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.npmjs.org/send/-/send-0.18.0.tgz"
@@ -11360,6 +11380,22 @@ ts-jest@^29.1.1:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
+ts-jest@^29.3.2:
+  version "29.3.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.3.2.tgz#0576cdf0a507f811fe73dcd16d135ce89f8156cb"
+  integrity sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==
+  dependencies:
+    bs-logger "^0.2.6"
+    ejs "^3.1.10"
+    fast-json-stable-stringify "^2.1.0"
+    jest-util "^29.0.0"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.7.1"
+    type-fest "^4.39.1"
+    yargs-parser "^21.1.1"
+
 tsconfig-paths@^3.14.2:
   version "3.14.2"
   resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz"
@@ -11420,6 +11456,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.39.1:
+  version "4.40.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.40.0.tgz#62bc09caccb99a75e1ad6b9b4653e8805e5e1eee"
+  integrity sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -12220,6 +12261,11 @@ ws@^8.13.0:
   version "8.14.2"
   resolved "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
+
+ws@^8.18.1:
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.1.tgz#ea131d3784e1dfdff91adb0a4a116b127515e3cb"
+  integrity sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==
 
 xlsx@^0.18.5:
   version "0.18.5"


### PR DESCRIPTION
I attempted to implement integration tests using Jest. If this aligns with your expectations, please review it. Alternatively, I can implement frontend tests using Cypress as well.

To run the tests in the `formstr-app` directory, use the following command:
```
npx jest --detectOpenHandles --forceExit --runInBand src/formLifecycle.test.ts
```

I've encountered one open handle that may prevent Jest from exiting properly. I tried to resolve this issue, but I suspect it is related to the `nostr-tools` library, as it manages sockets and timers internally.