### PR TITLE
added ability to zap self signed responses

### DIFF
--- a/packages/formstr-app/src/containers/ResponsesNew/index.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Event, getPublicKey, nip19, nip44, SubCloser } from "nostr-tools";
 import { useParams, useSearchParams } from "react-router-dom";
 import { fetchFormResponses } from "../../nostr/responses"
@@ -13,14 +13,30 @@ import { fetchKeys, getAllowedUsers, getFormSpec } from "../../utils/formUtils";
 import { Export } from "./Export";
 import { Field, Tag } from "../../nostr/types";
 import { useApplicationContext } from "../../hooks/useApplicationContext";
+import { getDefaultRelays } from "@formstr/sdk";
+import { ZapModal } from "./zapModal";
+import { ThunderboltFilled } from "@ant-design/icons";
+import { fetchProfiles, fetchZapReceipts, formatCompact, ProfileInfo, ZapInfo } from "../../utils/zapUtils";
 
 const { Text } = Typography;
+
+interface SelectedResponse {
+  pubkey: string;
+  lud16?: string;
+  name?: string;
+  eventId: string;
+}
 
 export const Response = () => {
   const [responses, setResponses] = useState<Event[] | undefined>(undefined);
   const [formEvent, setFormEvent] = useState<Event | undefined>(undefined);
   const [formSpec, setFormSpec] = useState<Tag[] | null | undefined>(undefined);
   const [editKey, setEditKey] = useState<string | undefined | null>();
+  const [profiles, setProfiles] = useState<Map<string, ProfileInfo>>(new Map());
+  const [zapAmounts, setZapAmounts] = useState<Map<string, ZapInfo>>(new Map());
+  const [zapModalVisible, setZapModalVisible] = useState<boolean>(false);
+  const [selectedResponse, setSelectedResponse] = useState<SelectedResponse | null>(null);
+
   let { pubKey, formId, secretKey } = useParams();
   let [searchParams] = useSearchParams();
   const { pubkey: userPubkey, requestPubkey } = useProfileContext();
@@ -30,13 +46,20 @@ export const Response = () => {
     setResponses((prev: Event[] | undefined) => [...(prev || []), event]);
   };
   let { poolRef } = useApplicationContext();
+  const relays = useMemo(() => getDefaultRelays(), []);
 
+  useEffect(() => {
+    if (responses?.length && poolRef?.current) {
+      fetchProfilesAndZaps();
+    }
+  }, [responses, poolRef?.current]);
+  
   const initialize = async () => {
     if (!formId) return;
 
     if (!(pubKey || secretKey)) return;
 
-    if(!poolRef) return
+    if (!poolRef) return
 
     if (secretKey) {
       setEditKey(secretKey);
@@ -67,7 +90,7 @@ export const Response = () => {
     let allowedPubkeys;
     let pubkeys = getAllowedUsers(formEvent);
     if (pubkeys.length !== 0) allowedPubkeys = pubkeys;
-    let responseCloser =  fetchFormResponses(
+    let responseCloser = fetchFormResponses(
       pubKey!,
       formId,
       poolRef.current,
@@ -82,8 +105,42 @@ export const Response = () => {
     if (!formEvent && !responses) initialize();
     return () => {
       if (responseCloser) responseCloser.close()
-      }
+    }
   }, [poolRef]);
+
+
+  const fetchProfilesAndZaps = async () => {
+    if (!responses || !poolRef?.current) return;
+
+    const pubkeysSet = new Set(responses.map(r => r.pubkey));
+    const pubkeys = Array.from(pubkeysSet);
+    const responseIds = responses.map(r => r.id);
+
+    const profilesData = await fetchProfiles(pubkeys, poolRef.current, relays);
+    setProfiles(profilesData);
+
+    const zapData = await fetchZapReceipts(responseIds, poolRef.current, relays);
+    setZapAmounts(zapData);
+  };
+
+  const handleZapClick = (responseEvent: Event) => {
+    const pubkey = responseEvent.pubkey;
+    const profile = profiles.get(pubkey);
+
+    if (!profile?.lud16) {
+      console.log("No lightning address found for this user");
+      return;
+    }
+
+    setSelectedResponse({
+      pubkey,
+      lud16: profile.lud16,
+      name: profile.displayName || profile.name,
+      eventId: responseEvent.id
+    });
+
+    setZapModalVisible(true);
+  };
 
   const getResponderCount = () => {
     if (!responses) return 0;
@@ -139,6 +196,7 @@ export const Response = () => {
         [key: string]: string;
       } = {
         key: response.pubkey,
+        eventId: response.id,
         createdAt: new Date(response.created_at * 1000).toDateString(),
         authorPubkey: nip19.npubEncode(response.pubkey),
         responsesCount: pubkeyResponses.length.toString(),
@@ -179,31 +237,73 @@ export const Response = () => {
       dataIndex: string;
       fixed?: "left" | "right";
       width?: number;
-      render?: (data: string) => JSX.Element;
+      render?: (data: string, record: any) => JSX.Element;
     }> = [
-      {
-        key: "author",
-        title: "Author",
-        fixed: "left",
-        dataIndex: "authorPubkey",
-        width: 1.2,
-        render: (data: string) => (
-          <a
-            href={`https://njump.me/${data}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {data}
-          </a>
-        ),
-      },
-      {
-        key: "responsesCount",
-        title: "Submissions",
-        dataIndex: "responsesCount",
-        width: 1.2,
-      },
-    ];
+        {
+          key: "author",
+          title: "Author",
+          fixed: "left",
+          dataIndex: "authorPubkey",
+          width: 1,
+          render: (data: string, record: any) => {
+            const pubkey = record.key;
+            const eventId = record.eventId;
+            const profile = profiles.get(pubkey);
+            const zapInfo = zapAmounts.get(eventId);
+            const hasLud16 = profile && profile.lud16;
+            const truncatedNpub = data.length > 14
+              ? `${data.substring(0, 8)}...${data.substring(data.length - 6)}`
+              : data;
+
+            return (
+              <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '8px' }}>
+                <a
+                  href={`https://njump.me/${data}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={data}
+                >
+                  {profile?.name || truncatedNpub}
+                </a>
+
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  {hasLud16 && (
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<ThunderboltFilled style={{ color: '#f5a623' }} />}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleZapClick({
+                          id: eventId,
+                          pubkey,
+                          content: '',
+                          tags: [],
+                          created_at: 0,
+                          kind: 0,
+                          sig: ''
+                        } as Event);
+                      }}
+                    />
+                  )}
+
+                  {zapInfo && (
+                    <span style={{ fontSize: '0.85rem', color: '#f5a623' }}>
+                      {formatCompact(zapInfo.amount)} ({zapInfo.count})
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          },
+        },
+        {
+          key: "responsesCount",
+          title: "Submissions",
+          dataIndex: "responsesCount",
+          width: 1.2,
+        },
+      ];
     const rightColumns: Array<{
       key: string;
       title: string;
@@ -212,13 +312,13 @@ export const Response = () => {
       width?: number;
       render?: (data: string) => JSX.Element;
     }> = [
-      {
-        key: "createdAt",
-        title: "Created At",
-        dataIndex: "createdAt",
-        width: 1,
-      },
-    ];
+        {
+          key: "createdAt",
+          title: "Created At",
+          dataIndex: "createdAt",
+          width: 1,
+        },
+      ];
     let uniqueQuestionIds: Set<string> = new Set();
     responses?.forEach((response: Event) => {
       let responseTags = getInputs(response);
@@ -297,6 +397,18 @@ export const Response = () => {
             scroll={{ x: isMobile() ? 900 : 1500, y: "calc(65% - 400px)" }}
           />
         </div>
+        {selectedResponse && (
+          <ZapModal
+            visible={zapModalVisible}
+            onCancel={() => setZapModalVisible(false)}
+            recipientPubkey={selectedResponse.pubkey}
+            lud16={selectedResponse.lud16 || ''}
+            responseId={selectedResponse.eventId}
+            formId={formId || ''}
+            recipientName={selectedResponse.name}
+            relays={relays}
+          />
+        )}
       </ResponseWrapper>
     </div>
   );

--- a/packages/formstr-app/src/containers/ResponsesNew/zapModal.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/zapModal.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { Modal, Input, Button, message } from 'antd';
+import { createZapRequest } from '../../utils/zapUtils';
+import styled from 'styled-components';
+
+const ZapAmountButton = styled(Button)<{ $selected?: boolean }>`
+  margin: 5px;
+  background-color: ${props => props.$selected ? '#f0f0f0' : 'white'};
+  border: ${props => props.$selected ? '2px solid #1890ff' : '1px solid #d9d9d9'};
+`;
+
+const ZapButtonRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 15px;
+`;
+
+const ZapOptionsContainer = styled.div`
+  padding: 16px 0;
+`;
+
+interface ZapModalProps {
+  visible: boolean;
+  onCancel: () => void;
+  recipientPubkey: string;
+  lud16: string;
+  responseId: string;
+  formId: string;
+  recipientName?: string;
+  relays: string[];
+}
+
+export const ZapModal: React.FC<ZapModalProps> = ({
+  visible,
+  onCancel,
+  recipientPubkey,
+  lud16,
+  responseId,
+  formId,
+  recipientName,
+  relays
+}) => {
+  const [amount, setAmount] = useState<number>(21);
+  const [comment, setComment] = useState<string>('');
+  const [isZapping, setIsZapping] = useState<boolean>(false);
+
+  const zapOptions = [
+    { emoji: '👍', amount: 21 },
+    { emoji: '🚀', amount: 420 },
+    { emoji: '☕', amount: 1000 },
+    { emoji: '⚡', amount: 5000 },
+    { emoji: '❤️', amount: 10000 },
+    { emoji: '🔥', amount: 15000 },
+  ];
+
+  const handleZap = async () => {
+    if (amount <= 0) {
+      message.error('Please enter a valid amount');
+      return;
+    }
+
+    setIsZapping(true);
+    
+    try {
+      const lightningUrl = await createZapRequest(
+        recipientPubkey,
+        lud16,
+        responseId,
+        formId,
+        amount,
+        comment,
+        relays
+      );
+
+      if (lightningUrl) {
+        console.log("Opening lightning URL:", lightningUrl);
+        const paymentRequest = lightningUrl.replace('lightning:', '');
+
+        if (typeof window !== 'undefined' && (window as any).webln) {
+          try {
+            await (window as any).webln.enable();
+            await (window as any).webln.sendPayment(paymentRequest);
+            message.success("Zap sent successfully!");
+          } catch (err) {
+            console.error("WebLN payment failed:", err);
+            // Try to open with the lightning handler instead
+            window.location.href = lightningUrl;
+          }
+        } else {
+          // Fallback to direct lightning URL
+          window.location.href = lightningUrl;
+        }
+      } else {
+        message.error("Failed to create zap request");
+      }
+    } catch (error) {
+      message.error("Error processing zap");
+    } finally {
+      setIsZapping(false);
+      onCancel();
+    }
+  };
+
+  return (
+    <Modal
+      title={`Zap ${recipientName || 'User'}`}
+      open={visible}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        <Button
+          key="zap"
+          type="primary"
+          onClick={handleZap}
+          loading={isZapping}
+          style={{ backgroundColor: '#d63384' }}
+        >
+          Zap {amount} sats
+        </Button>
+      ]}
+    >
+      <ZapOptionsContainer>
+        <ZapButtonRow>
+          {zapOptions.map(option => (
+            <ZapAmountButton
+              key={option.amount}
+              $selected={amount === option.amount}
+              onClick={() => setAmount(option.amount)}
+            >
+              {option.emoji} {option.amount}
+            </ZapAmountButton>
+          ))}
+        </ZapButtonRow>
+        
+        <div>
+          <label>Custom amount:</label>
+          <Input
+            type="number"
+            value={amount}
+            onChange={e => setAmount(parseInt(e.target.value) || 0)}
+            min={1}
+            style={{ marginTop: 5, marginBottom: 15 }}
+          />
+        </div>
+
+        <div>
+          <label>Message:</label>
+          <Input.TextArea
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            placeholder="thank you 👍"
+            rows={2}
+            style={{ marginTop: 5 }}
+          />
+        </div>
+      </ZapOptionsContainer>
+    </Modal>
+  );
+};

--- a/packages/formstr-app/src/utils/zapUtils.ts
+++ b/packages/formstr-app/src/utils/zapUtils.ts
@@ -1,0 +1,205 @@
+import { message } from "antd";
+import { nip19, nip57 } from "nostr-tools";
+import type { SimplePool } from "nostr-tools";
+
+export interface ZapInfo {
+  amount: number;
+  count: number;
+}
+
+export interface ProfileInfo {
+  lud16?: string;
+  name?: string;
+  picture?: string;
+  displayName?: string;
+}
+
+export const fetchProfiles = async (
+  pubkeys: string[],
+  pool: SimplePool,
+  relays: string[]
+): Promise<Map<string, ProfileInfo>> => {
+  const profiles = new Map<string, ProfileInfo>();
+  if (!pubkeys.length) return profiles;
+  
+  try {
+    const events = await pool.querySync(
+      relays,
+      { kinds: [0], authors: pubkeys },
+      { maxWait: 3000 }
+    );
+    
+    for (const event of events) {
+      try {
+        const content = JSON.parse(event.content);
+        profiles.set(event.pubkey, {
+          lud16: content.lud16 || content.lightning,
+          name: content.name,
+          picture: content.picture,
+          displayName: content.display_name || content.displayName
+        });
+      } catch (e) {
+        console.error("Failed to parse profile content", e);
+      }
+    }
+  } catch (error) {
+    console.error("Error fetching profiles:", error);
+  }
+  
+  return profiles;
+};
+
+export const fetchZapReceipts = async (
+  eventIds: string[],
+  pool: SimplePool,
+  relays: string[]
+): Promise<Map<string, ZapInfo>> => {
+  const zapAmounts = new Map<string, ZapInfo>();
+  if (!eventIds.length) return zapAmounts;
+
+  try {
+    const events = await pool.querySync(
+      relays,
+      { kinds: [9735], "#e": eventIds },
+      { maxWait: 3000 }
+    );
+
+    for (const zapReceipt of events) {
+      // Find the zapped event ID from the tags
+      const eventTag = zapReceipt.tags.find(tag => tag[0] === 'e');
+      if (!eventTag?.[1]) continue;
+
+      const eventId = eventTag[1];
+
+      // Extract the amount from the zap receipt
+      const amountTag = zapReceipt.tags.find(tag => tag[0] === 'amount');
+      if (!amountTag?.[1]) continue;
+
+      const amount = parseInt(amountTag[1]) / 1000; // Convert msats to sats
+
+      const currentInfo = zapAmounts.get(eventId) || { amount: 0, count: 0 };
+      zapAmounts.set(eventId, {
+        amount: currentInfo.amount + amount,
+        count: currentInfo.count + 1
+      });
+    }
+  } catch (error) {
+    console.error("Error fetching zap receipts:", error);
+  }
+
+  return zapAmounts;
+};
+
+export const createZapRequest = async (
+  recipientPubkey: string,
+  lud16: string,
+  eventId: string,
+  formId: string,
+  amount: number,
+  comment = "",
+  relays: string[]
+): Promise<string | null> => {
+  if (!lud16) return null;
+  
+  try {
+    if (!relays?.length) {
+      relays = ["wss://relay.damus.io", "wss://nos.lol"];
+    }
+    
+    const unsignedZapRequest = nip57.makeZapRequest({
+      profile: recipientPubkey,
+      event: eventId,
+      amount: amount * 1000,
+      comment,
+      relays
+    });
+    unsignedZapRequest.tags.push(["e", formId, "", "root"]);
+    
+    let signedZapRequest = unsignedZapRequest;
+    const nostr = typeof window !== "undefined" ? (window as any).nostr : null;
+    
+    if (nostr?.signEvent) {
+      try {
+        signedZapRequest = await nostr.signEvent(unsignedZapRequest);
+      } catch {
+        message.error("You need to sign the zap request with your Nostr extension (e.g. Alby).");
+        return null;
+      }
+    } else {
+      message.error("No Nostr extension (NIP-07) found. Please install Alby or another Nostr browser extension.");
+      return null;
+    }
+    
+    // Get zap endpoint
+    let zapEndpoint;
+    if (lud16.includes('@')) {
+      const [name, domain] = lud16.split('@');
+      zapEndpoint = `https://${domain}/.well-known/lnurlp/${name}`;
+    } else {
+      try {
+        const metadataEvent = {
+          kind: 0,
+          content: JSON.stringify({ lud16 }),
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [],
+          pubkey: recipientPubkey,
+          id: '',
+          sig: ''
+        };
+        zapEndpoint = await nip57.getZapEndpoint(metadataEvent);
+      } catch {
+        if (lud16.toLowerCase().startsWith('lnurl')) {
+          try {
+            const decoded = nip19.decode(lud16);
+            if (decoded?.data) {
+              zapEndpoint = decoded.data.toString();
+            }
+          } catch {}
+        }
+      }
+    }
+    
+    if (!zapEndpoint) return null;
+    
+    // Make the zap request
+    const zapRequestString = btoa(JSON.stringify(signedZapRequest));
+    const callbackUrl = new URL(zapEndpoint);
+    callbackUrl.searchParams.set("amount", (amount * 1000).toString());
+    callbackUrl.searchParams.set("nostr", zapRequestString);
+    if (comment) callbackUrl.searchParams.set("comment", comment);
+    
+    const response = await fetch(callbackUrl.toString());
+    if (!response.ok) return null;
+    
+    const zapResponse = await response.json();
+    
+    // Handle callback scenario
+    if (zapResponse.callback) {
+      const callbackUrl2 = new URL(zapResponse.callback);
+      callbackUrl2.searchParams.set("amount", (amount * 1000).toString());
+      callbackUrl2.searchParams.set("nostr", zapRequestString);
+      if (comment) callbackUrl2.searchParams.set("comment", comment);
+      
+      const invoiceResponse = await fetch(callbackUrl2.toString());
+      if (!invoiceResponse.ok) return null;
+      
+      const invoiceJson = await invoiceResponse.json();
+      if (!invoiceJson.pr) return null;
+      
+      return `lightning:${invoiceJson.pr}`;
+    }
+    
+    // Direct PR scenario
+    if (!zapResponse.pr) return null;
+    return `lightning:${zapResponse.pr}`;
+  } catch {
+    return null;
+  }
+};
+
+export const formatCompact = (num: number): string => {
+  return new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1
+  }).format(num);
+};


### PR DESCRIPTION
Flow of Operation:
- When viewing responses, the app fetches profiles and zap information
- For each responder with a Lightning address, a zap button appears
- When a user clicks a zap button, the zap modal opens
- The user selects an amount and optional comment
- Upon confirming, the app:
    - Creates a zap request with proper NIP-57 formatting
    - Attempts payment via WebLN
    - Falls back to a Lightning URL if WebLN isn't available
    
@abh3po, whenever you are free, please review this. I struggled a bit because I didn't know about WebLN, which I learned about when I looked through the Primal implementation. WebLN makes it look so smooth.

https://github.com/user-attachments/assets/dfdb8f3b-04c4-441c-9df8-95fd24719030


resolves #271 