### PR TITLE
dropdown Menu consistent in dashbaord

### DIFF
--- a/packages/formstr-app/src/containers/Dashboard/FormCards/MyForms.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/FormCards/MyForms.tsx
@@ -161,8 +161,15 @@ export const MyForms = () => {
 
   useEffect(() => {
     if (userPub) {
+      // Reset state and fetch forms on mount
+      setFormEvents(new Map()); // Clear previous forms
+      setRefreshing(true); // Show loading spinner
       fetchMyForms();
     }
+    // Cleanup on unmount
+    return () => {
+      setRefreshing(false); // Reset refreshing state
+    };
   }, [userPub]);
 
   return (

--- a/packages/formstr-app/src/containers/Dashboard/index.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/index.tsx
@@ -31,6 +31,11 @@ const MENU_OPTIONS = {
 
 const defaultRelays = getDefaultRelays();
 
+type FilterType = "local" | "shared" | "myForms" | "drafts";
+const SESSION_STORAGE_KEYS = {
+  DASHBOARD_FILTER: "dashboard_filter",
+};
+
 export const Dashboard = () => {
   const { state } = useLocation();
   const { pubkey } = useProfileContext();
@@ -39,9 +44,19 @@ export const Dashboard = () => {
     getItem(LOCAL_STORAGE_KEYS.LOCAL_FORMS) || []
   );
   const [nostrForms, setNostrForms] = useState<Map<string, Event>>(new Map());
-  const [filter, setFilter] = useState<
-    "local" | "shared" | "myForms" | "drafts"
-  >("local");
+  //const [filter, setFilter] = useState<"local" | "shared" | "myForms" | "drafts">("local");
+  const [filter, setFilter] = useState<FilterType>(() => {
+  
+    const storedFilter = sessionStorage.getItem(SESSION_STORAGE_KEYS.DASHBOARD_FILTER);
+   
+    const validFilters: FilterType[] = ["local", "shared", "myForms", "drafts"];
+    return storedFilter && validFilters.includes(storedFilter as FilterType)
+      ? (storedFilter as FilterType)
+      : "local"; // Default to "local" if invalid or not found
+  });
+  useEffect(() => {
+    sessionStorage.setItem(SESSION_STORAGE_KEYS.DASHBOARD_FILTER, filter);
+  },[filter])
 
   const { poolRef, isTemplateModalOpen, closeTemplateModal } = useApplicationContext();
 


### PR DESCRIPTION
This makes the dropdown menu consistent and the filter is saved in the sessionStorage, so when the user to other page for ex: in my forms and come back to the dashboard the 'myForms' filter is restored from sessionStorage. 