### PR TITLE
Close icon not working after submitting a downloaded form

### DIFF
--- a/packages/formstr-app/src/containers/FormFillerNew/index.tsx
+++ b/packages/formstr-app/src/containers/FormFillerNew/index.tsx
@@ -152,7 +152,9 @@ export const FormFiller: React.FC<FormFillerProps> = ({
         />
         <ThankYouScreen
           isOpen={formSubmitted}
-          onClose={() => navigate(ROUTES.DASHBOARD)}
+          onClose={() => {
+            setFormSubmitted(false);
+            navigate(ROUTES.DASHBOARD)}}
         />
       </>
     );


### PR DESCRIPTION
Issue: Close icon not working after form submission of downloaded form.
Fix: Replaced direct navigation to dashboard with a function that first sets formSubmitted to false and then navigate.